### PR TITLE
chore(Jenkinsfile): re-fetch the tags before building the canary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
             }
             steps {
                 milestone 1
+                sh "git fetch --tags"
                 container('node') {
                     sh "yarn install"
                     sh "yarn lerna bootstrap"


### PR DESCRIPTION
Due to concurrent builds, a new tag may have been created while we were building and testing.