### PR TITLE
Fix #15 Pass all form attrs to the evaluator

### DIFF
--- a/packages/core-ui/src/modules/react-components/Form.js
+++ b/packages/core-ui/src/modules/react-components/Form.js
@@ -712,12 +712,12 @@ var Form = React.createClass({
                     break;
                 case 'CATEGORICAL':
                 case 'XREF':
-                    form[attr.name] = value === null || value === undefined ? value :value[attr.refEntity.idAttribute];
+                    form[attr.name] = value === null || value === undefined ? value : value[attr.refEntity.idAttribute];
                     break;
                 case 'CATEGORICAL_MREF':
                 case 'MREF':
                 case 'ONE_TO_MANY':
-                    form[attr.name] = value === null || value === undefined ? _.map(value.items, function (item) {
+                    form[attr.name] = value === null || value === undefined ? value : _.map(value.items, function (item) {
                         return item[attr.refEntity.idAttribute];
                     }).join();
                     break;

--- a/packages/core-ui/src/modules/react-components/Form.js
+++ b/packages/core-ui/src/modules/react-components/Form.js
@@ -703,33 +703,32 @@ var Form = React.createClass({
         _.each(this.state.entity.allAttributes, function (attr) {
             var value = entityInstance[attr.name];
 
-            if (value !== null && value !== undefined) {
-                switch (attr.fieldType) {
-                    case 'DATE':
-                        form[attr.name] = moment(value, 'YYYY-MM-DD', true);
-                        break;
-                    case 'DATE_TIME':
-                        form[attr.name] = moment(value, moment.ISO_8601, true);
-                        break;
-                    case 'CATEGORICAL':
-                    case 'XREF':
-                        form[attr.name] = value[attr.refEntity.idAttribute];
-                        break;
-                    case 'CATEGORICAL_MREF':
-                    case 'MREF':
-                    case 'ONE_TO_MANY':
-                        form[attr.name] = _.map(value.items, function (item) {
-                            return item[attr.refEntity.idAttribute];
-                        }).join();
-                        break;
-                    case 'COMPOUND':
-                        //nothing, no value
-                        break;
-                    default:
-                        form[attr.name] = value;
-                        break;
-                }
+            switch (attr.fieldType) {
+                case 'DATE':
+                    form[attr.name] = moment(value, 'YYYY-MM-DD', true);
+                    break;
+                case 'DATE_TIME':
+                    form[attr.name] = moment(value, moment.ISO_8601, true);
+                    break;
+                case 'CATEGORICAL':
+                case 'XREF':
+                    form[attr.name] = value === null || value === undefined ? value :value[attr.refEntity.idAttribute];
+                    break;
+                case 'CATEGORICAL_MREF':
+                case 'MREF':
+                case 'ONE_TO_MANY':
+                    form[attr.name] = _.map(value.items, function (item) {
+                        return item[attr.refEntity.idAttribute];
+                    }).join();
+                    break;
+                case 'COMPOUND':
+                    //nothing, no value
+                    break;
+                default:
+                    form[attr.name] = value;
+                    break;
             }
+
         }, this);
 
         try {

--- a/packages/core-ui/src/modules/react-components/Form.js
+++ b/packages/core-ui/src/modules/react-components/Form.js
@@ -717,7 +717,7 @@ var Form = React.createClass({
                 case 'CATEGORICAL_MREF':
                 case 'MREF':
                 case 'ONE_TO_MANY':
-                    form[attr.name] = _.map(value.items, function (item) {
+                    form[attr.name] = value === null || value === undefined ? _.map(value.items, function (item) {
                         return item[attr.refEntity.idAttribute];
                     }).join();
                     break;


### PR DESCRIPTION
, even if value is null or undefined, still pass attribute.

Fix #15 

- This is needed because the evaluator now throws an error is expected attribute is missing.
- Change introduced in molgenis ref b24d9ad028f53462aeaa2248996bfc96c9b6e27d, evaluator.js api change attributes can no longer be null or undefined

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
