### PR TITLE
FIX #7716

### DIFF
--- a/packages/questionnaires/src/pages/QuestionnaireStart.vue
+++ b/packages/questionnaires/src/pages/QuestionnaireStart.vue
@@ -21,7 +21,12 @@
           <p v-html="questionnaireDescription"></p>
 
           <button class="btn btn-lg btn-primary mt-2 float-right" @click="startQuestionnaire">
-            {{ 'questionnaire_start' | i18n }}
+            <template v-if="isStarted">
+              {{ 'questionnaires_table_continue_questionnaire_button' | i18n }}
+            </template>
+            <template v-else>
+             {{ 'questionnaire_start' | i18n }}
+            </template>
           </button>
         </template>
 
@@ -58,6 +63,9 @@
       },
       questionnaireList () {
         return this.$store.state.questionnaireList
+      },
+      isStarted () {
+        return this.$store.getters.isStarted(this.questionnaireId)
       }
     },
     created () {

--- a/packages/questionnaires/src/store/getters.js
+++ b/packages/questionnaires/src/store/getters.js
@@ -195,6 +195,10 @@ const getters = {
 
   getQuestionLabel: (state: QuestionnaireState): Function => (questionId: string) => {
     return getQuestionById(state.chapters, questionId).label
+  },
+
+  isStarted: (state: QuestionnaireState): Function => (questionnaireId: string) => {
+    return state.questionnaireList.find((questionnaire) => questionnaire.id === questionnaireId).status !== 'NOT_STARTED'
   }
 }
 

--- a/packages/questionnaires/test/unit/specs/components/QuestionnaireStart.spec.js
+++ b/packages/questionnaires/test/unit/specs/components/QuestionnaireStart.spec.js
@@ -34,6 +34,7 @@ describe('QuestionnaireStart component', () => {
     getters = {
       getQuestionnaireLabel: () => () => 'label',
       getQuestionnaireDescription: () => () => 'description',
+      isStarted: () => () => true,
       questionnaireList: () => []
     }
 
@@ -86,6 +87,11 @@ describe('QuestionnaireStart component', () => {
   it('should retrieve the label from the store', () => {
     const wrapper = shallow(QuestionnaireStart, {propsData, store, stubs, localVue, mocks})
     expect(wrapper.vm.questionnaireLabel).to.equal('label')
+  })
+
+  it('should retrieve if the questionnaire is started', () => {
+    const wrapper = shallow(QuestionnaireStart, {propsData, store, stubs, localVue, mocks})
+    expect(wrapper.vm.isStarted).to.equal(true)
   })
 
   it('should return error from the store', () => {

--- a/packages/questionnaires/test/unit/specs/store/getters.spec.js
+++ b/packages/questionnaires/test/unit/specs/store/getters.spec.js
@@ -241,7 +241,7 @@ describe('getters', () => {
       }
     },
     questionnaireList: [
-      {id: 'q1', label: 'questionaire1', description: 'desc1', status: 'OPEN'},
+      {id: 'q1', label: 'questionaire1', description: 'desc1', status: 'NOT_STARTED'},
       {id: 'q2', label: 'questionaire2', description: 'desc2', status: 'OPEN'}
     ]
   }
@@ -451,6 +451,16 @@ describe('getters', () => {
     it('should thrown an exception if the given id is not a question id', () => {
       const questionId = 'non-existent-id'
       expect(() => getters.getQuestionLabel(state)(questionId)).to.throw()
+    })
+  })
+
+  describe('isStarted', () => {
+    it('should return false is the questionnaire is not started', () => {
+      expect(getters.isStarted(state)(state.questionnaireList[0].id)).to.equal(false)
+    })
+
+    it('should return true is the questionnaire is started', () => {
+      expect(getters.isStarted(state)(state.questionnaireList[1].id)).to.equal(true)
     })
   })
 })


### PR DESCRIPTION
FIX #7716

When I already started my questionnaire
button still says "start questionnaire"
instead of "continue questionnaire"

- flip text on questionnaire state

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
-  No warnings during install
-  Updated javascript typing
