### PR TITLE
fix(data-row-edit): Fix 8356, use i18n bool values

### DIFF
--- a/packages/data-row-edit/src/components/DataRowEdit.vue
+++ b/packages/data-row-edit/src/components/DataRowEdit.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script>
-  import { FormComponent } from '@molgenis/molgenis-ui-form'
+  import { FormComponent, EntityToFormMapper as mapper } from '@molgenis/molgenis-ui-form'
   import '../../node_modules/@molgenis/molgenis-ui-form/dist/static/css/molgenis-ui-form.css'
   import * as repository from '@/repository/dataRowRepository'
 
@@ -131,16 +131,25 @@
         }
         this.showForm = true
         this.isSaving = false
-      },
-      initializeForm (mappedData) {
-        this.formFields = mappedData.formFields
-        this.formData = mappedData.formData
-        this.dataTableLabel = mappedData.formLabel
-        this.showForm = true
       }
     },
     created: function () {
-      repository.fetch(this.dataTableId, this.dataRowId).then(this.initializeForm, this.handleError)
+      const mapperOptions = {
+        showNonVisibleAttributes: true,
+        mapperMode: this.dataRowId ? 'UPDATE' : 'CREATE',
+        booleanLabels: {
+          trueLabel: this.$t('data-row-edit-boolean-true'),
+          falseLabel: this.$t('data-row-edit-boolean-false'),
+          nillLabel: this.$t('data-row-edit-boolean-null')
+        }
+      }
+      repository.fetch(this.dataTableId, this.dataRowId).then(resp => {
+        this.dataTableLabel = resp.meta.label
+        const mappedData = mapper.generateForm(resp.meta, resp.rowData, mapperOptions)
+        this.formFields = mappedData.formFields
+        this.formData = mappedData.formData
+        this.showForm = true
+      }, this.handleError)
     },
     components: {
       FormComponent

--- a/packages/data-row-edit/src/repository/dataRowRepository.js
+++ b/packages/data-row-edit/src/repository/dataRowRepository.js
@@ -1,9 +1,4 @@
-import { EntityToFormMapper } from '@molgenis/molgenis-ui-form'
 import api from '@molgenis/molgenis-api-client'
-
-const entityMapperSettings = {
-  showNonVisibleAttributes: true
-}
 
 const isFileIncluded = (formData, formFields) => {
   const fieldsWithFile = formFields
@@ -45,33 +40,22 @@ const doPost = (uri, formData, formFields) => {
 }
 
 /**
- * response mixes data and metadata, this function creates a new object with separate properties for data and metadata
+ * Fetch for edit-response mixes data and metadata,
+ * this function creates a new object with separate properties for data and metadata, similar to the
+ * fetch for create response
  * @param response
- * @returns {{_meta: *, rowData: *}}
+ * @returns Promise{{meta: *, rowData: *}}
  */
 const parseEditResponse = (response) => {
   // noinspection JSUnusedLocalSymbols
   const { _meta, _href, ...rowData } = response
-  return {_meta, rowData}
+  return Promise.resolve({meta: _meta, rowData: rowData})
 }
 
-const fetchForCreate = (tableId) => {
-  return new Promise((resolve, reject) => {
-    api.get('/api/v2/' + tableId + '?num=0').then((response) => {
-      const mappedData = EntityToFormMapper.generateForm(response.meta, {}, { mapperMode: 'CREATE', ...entityMapperSettings })
-      resolve({formLabel: response.meta.label, ...mappedData})
-    }, reject)
-  })
-}
+const fetchForCreate = (tableId) => api.get('/api/v2/' + tableId + '?num=0')
 
 const fetchForUpdate = (tableId, rowId) => {
-  return new Promise((resolve, reject) => {
-    api.get('/api/v2/' + tableId + '/' + rowId).then((response) => {
-      const {_meta, rowData} = parseEditResponse(response)
-      const mappedData = EntityToFormMapper.generateForm(_meta, rowData, { mapperMode: 'UPDATE', ...entityMapperSettings })
-      resolve({formLabel: response._meta.label, ...mappedData})
-    }, reject)
-  })
+  return api.get('/api/v2/' + tableId + '/' + rowId).then(response => parseEditResponse(response))
 }
 
 const create = (formData, formFields, tableId) => {

--- a/packages/data-row-edit/test/unit/specs/repository/dataRowRepository.spec.js
+++ b/packages/data-row-edit/test/unit/specs/repository/dataRowRepository.spec.js
@@ -1,5 +1,4 @@
 import td from 'testdouble'
-import { EntityToFormMapper } from '@molgenis/molgenis-ui-form'
 import api from '@molgenis/molgenis-api-client'
 import * as repository from '@/repository/dataRowRepository'
 
@@ -69,26 +68,15 @@ describe('Data row repository', () => {
 
   describe('fetch', () => {
     it('when no rowId is set fetch the table structure and map it to form data', (done) => {
-      td.replace(EntityToFormMapper, 'generateForm', () => {
-        return {a: 'b'}
-      })
-
-      repository.fetch('tableId', null).then((mappedData) => {
-        expect(mappedData.formLabel).to.equal('for create label')
-        done()
-      }, () => {
+      repository.fetch('tableId', null).then(() => done(), () => {
         expect(true).to.equal(false) // fail test in case rejection
         done()
       })
     })
 
     it('when rowId is set fetch the table structure and data and map it to form data', (done) => {
-      td.replace(EntityToFormMapper, 'generateForm', () => {
-        return {c: 'd'}
-      })
-
-      repository.fetch('tableId', 'rowId').then((mappedData) => {
-        expect(mappedData.formLabel).to.equal('for update label')
+      repository.fetch('tableId', 'rowId').then((resp) => {
+        expect(resp.meta.label).to.equal('for update label')
         done()
       }, () => {
         expect(true).to.equal(false) // fail test in case rejection


### PR DESCRIPTION
Fix #8357

- Use i18n bool values when mapping entity
- Move mapping from repository to vue component to make use of i18n plugin and cleanup repository.

Note: new i18n values need to set in molgenis data-row-edit param files and loaded in the database.

related to: https://github.com/molgenis/molgenis/pull/8407
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
