### PR TITLE
fix(one-click-importer): Set height of file input to 100%

### DIFF
--- a/packages/one-click-importer/src/components/OneClickImporter.vue
+++ b/packages/one-click-importer/src/components/OneClickImporter.vue
@@ -7,7 +7,7 @@
             <label for="file-input">{{ 'import-input-label' | i18n }}</label>
             <input
               id="file-input"
-              class="form-control"
+              class="form-control molgenis-file-input"
               ref="fileInput"
               type="file"
               accept=".csv, .zip, .xls, .xlsx, text/csv, application/zip, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
@@ -96,6 +96,13 @@
     margin-left: 1rem;
     padding-top: 0.5em;
     font-size: smaller;
+  }
+
+  /** This is required when alternative bootstrap themes are used. The sass compiler somehow sets the height to a
+  magically calculated number and makes the button of the file upload too big in firefox and poorly positioned in other
+  browsers.*/
+  .molgenis-file-input {
+    height: 100%;
   }
 </style>
 


### PR DESCRIPTION
Set height of file input in one click importer to 100% to override the faulty bootstrap theme
calculation. We chose to keep the current file input rather than replace it by the bootstrap one
because we like the browser translations, those are lost when the bootstrap variant is used.

Fixes molgenis/molgenis#8368

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
