### PR TITLE
Fix #56: Cannot add group with name of subpackage

### DIFF
--- a/packages/security/src/store/actions.js
+++ b/packages/security/src/store/actions.js
@@ -144,7 +144,7 @@ const actions = {
   },
 
   'checkRootPackageExists' ({commit, dispatch}: { commit: Function, dispatch: Function }, packageName) {
-    const url = '/api/v2/sys_md_Package?&num=1&q=label==\'' + encodeURIComponent(packageName) + '\';parent==\'\''
+    const url = '/api/v2/sys_md_Package?&num=1&q=id==\'' + encodeURIComponent(packageName) + '\''
 
     return new Promise((resolve, reject) => {
       api.get(url).then((response) => {


### PR DESCRIPTION
fixes #56

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
