### PR TITLE
fix(menu): Fix #8481 Bump molgenis-ui-context (0.5 -> 1.x) and use ne…

### DIFF
--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -19,7 +19,7 @@
     "unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "@molgenis/molgenis-ui-context": "^0.5.2",
+    "@molgenis/molgenis-ui-context": "^1.0.0",
     "vue": "^2.5.17"
   },
   "devDependencies": {

--- a/packages/menu/src/App.vue
+++ b/packages/menu/src/App.vue
@@ -1,19 +1,19 @@
 <template>
   <div id="molgenis-site-menu">
-    <CookieWall v-if="showCookieWall" cookieName="permissionforcookies" />
-    <NavBar :molgenis-menu="molgenisMenu"></NavBar>
+    <cookie-wall v-if="showCookieWall" cookieName="permissionforcookies" />
+    <header-component :molgenis-menu="molgenisMenu"/>
   </div>
 </template>
 
 <script>
 import Vue from 'vue'
-import NavBar from '../node_modules/@molgenis/molgenis-ui-context/src/components/NavBar.vue'
+import HeaderComponent from '../node_modules/@molgenis/molgenis-ui-context/src/components/HeaderComponent.vue'
 import CookieWall from '../node_modules/@molgenis/molgenis-ui-context/src/components/CookieWall'
 
 export default Vue.extend({
   name: 'molgenis-site-menu',
   components: {
-    NavBar, CookieWall
+    HeaderComponent, CookieWall
   },
   data () {
     return {

--- a/packages/menu/yarn.lock
+++ b/packages/menu/yarn.lock
@@ -669,10 +669,10 @@
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.4"
 
-"@molgenis/molgenis-ui-context@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-ui-context/-/molgenis-ui-context-0.5.2.tgz#9a53b622e8f1ec2af9670262ac49e456f927eb1f"
-  integrity sha512-cfuK+itg9OdhQqQjFqpvwrrC7+bpZxTgMRN7yRjOf5XK+e4m91of7/Bu5GShNW2JJAlegNt4U3yDYpmrFCvmxw==
+"@molgenis/molgenis-ui-context@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-ui-context/-/molgenis-ui-context-1.0.0.tgz#831004641b065635d922be5efc27ea4828cfb415"
+  integrity sha512-Xu7nY0xpvQ6RhO0kP0rbpB3HWvv28hycfrfnTDxN50CXN9yLcfJwimaKENzOHqnsJryAp8eM/rxyWVAFNDC22A==
   dependencies:
     "@molgenis/molgenis-api-client" "^3.1.0"
 


### PR DESCRIPTION
…w sticky header feature

Blocks in release of [sticky header feature](https://github.com/molgenis/molgenis-ui-context/pull/51) in molgenis-ui-context repo

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
