### PR TITLE
fix(core-ui): use promise for localization call

### DIFF
--- a/packages/core-ui/src/modules/i18n/I18nStrings.js
+++ b/packages/core-ui/src/modules/i18n/I18nStrings.js
@@ -4,17 +4,15 @@ let i18nStrings = undefined;
 
 export function I18nStrings(callback) {
     if (!i18nStrings) {
-        $.ajax({
-            type: 'GET',
-            url: '/api/v2/i18n',
-            contentType: 'application/json',
-            async: true,
-            success: function (data) {
-                i18nStrings = data;
-                callback(data);
-            }
-        });
-    } else {
-        callback(i18nStrings);
+        i18nStrings = new Promise(function(resolve, reject) {
+            $.ajax({
+                type: 'GET',
+                url: '/api/v2/i18n',
+                contentType: 'application/json',
+                async: true,
+                success: resolve
+            });
+        })
     }
+    i18nStrings.then(callback)
 }


### PR DESCRIPTION
Fixes #126

The idea is to create a single promise when the first request comes in and then to share the results with all other requests.

#### Checklist
- [ ] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
