### PR TITLE
chore(core-ui): cache proxy config for max 600s

### DIFF
--- a/docker/proxy-config/proxy.d/common.conf
+++ b/docker/proxy-config/proxy.d/common.conf
@@ -12,4 +12,6 @@ location @handle_redirect {
   set $frontend_host 'https://unpkg.com';
   set $saved_redirect_location '$upstream_http_location';
   proxy_pass $frontend_host$saved_redirect_location;
+  # Do not cache these redirects too long
+  expires 10m;
 }

--- a/docker/proxy-config/proxy.d/frontend/lts.conf
+++ b/docker/proxy-config/proxy.d/frontend/lts.conf
@@ -27,4 +27,7 @@ location /@molgenis-ui/ {
   proxy_intercept_errors on;
   recursive_error_pages on;
   error_page 301 302 307 = @handle_redirect;
+
+  # do not cache these lts rewrites too long
+  expires 10m;
 }


### PR DESCRIPTION
The unpkg resources with specific versions have long expiry dates.
If we get there using a fully versioned URL that is correct.

If we got there because we're following unpkg redirects it is incorrect.
The redirects may change.

If we get there because we've rewritten directly to a specific version
it is also incorrect. The proxy config may change.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
