### PR TITLE
fix(data-explorer): default store settings get overridden by non-exis…

### DIFF
--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -50,11 +50,23 @@ export default {
     state.entityMetaRefs = refItems
   },
   setTableSettings (state: ApplicationState, tableSettings: StringMap) {
-    state.tableSettings.isShop = Boolean(tableSettings.shop)
-    state.tableSettings.collapseLimit = parseInt(tableSettings.collapse_limit)
-    state.tableSettings.settingsRowId = tableSettings.id
-    state.tableSettings.customCardCode = tableSettings.card_template
-    state.tableSettings.customCardAttrs = tableSettings.template_attrs
+    const isPropSet = (prop: string) => typeof tableSettings[prop] !== 'undefined'
+
+    if (isPropSet('shop')) {
+      state.tableSettings.isShop = Boolean(tableSettings.shop)
+    }
+    if (isPropSet('collapse_limit')) {
+      state.tableSettings.collapseLimit = parseInt(tableSettings.collapse_limit)
+    }
+    if (isPropSet('id')) {
+      state.tableSettings.settingsRowId = tableSettings.id
+    }
+    if (isPropSet('card_template')) {
+      state.tableSettings.customCardCode = tableSettings.card_template
+    }
+    if (isPropSet('template_attrs')) {
+      state.tableSettings.customCardAttrs = tableSettings.template_attrs
+    }
   },
   setMetaData (state: ApplicationState, meta: MetaDataApiResponse) {
     state.tableMeta = meta

--- a/packages/data-explorer/tests/e2e/specs/test.js
+++ b/packages/data-explorer/tests/e2e/specs/test.js
@@ -32,15 +32,6 @@ module.exports = {
       .waitForElementVisible('.alert.alert-warning', timeOutDelay)
       .end()
   },
-  'expand card button is not present for cards with less than 5 elements': browser => {
-    browser
-      .url(process.env.VUE_DEV_SERVER_URL)
-      .waitForElementVisible('#app', timeOutDelay)
-      .click('.jumbotron .btn.btn-primary.btn-lg')
-      .pause(animationDelay)
-      .assert.elementNotPresent('.mg-card-expand')
-      .end()
-  },
   'should display custom card': browser => {
     browser
       .url(process.env.VUE_DEV_SERVER_URL + 'TableWithCustomCard')


### PR DESCRIPTION
…ting props from server.

- Check if setting has been set in the backend, if not keep the current setting.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
