### PR TITLE
fix(data-explorer): load deep data when showing clipboard 

### DIFF
--- a/packages/data-explorer/src/views/ClipboardView.vue
+++ b/packages/data-explorer/src/views/ClipboardView.vue
@@ -34,7 +34,7 @@
 <script>
 import TableRow from '../components/dataView/TableRow'
 import TableHeader from '../components/dataView/TableHeader'
-import { mapState, mapMutations } from 'vuex'
+import { mapState, mapMutations, mapActions } from 'vuex'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faShoppingBag, faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -44,7 +44,7 @@ export default {
   name: 'ClipboardView',
   components: { TableRow, TableHeader, FontAwesomeIcon },
   computed: {
-    ...mapState(['tableMeta', 'shoppedEntityItems', 'tableData']),
+    ...mapState(['tableMeta', 'shoppedEntityItems', 'tableData', 'tableName']),
     idAttribute () {
       return this.tableMeta.idAttribute
     },
@@ -56,6 +56,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions(['fetchTableViewData']),
     ...mapMutations(['setShowShoppingCart', 'setHideFilters']),
     getEntityId (entity) {
       return entity[this.idAttribute].toString()
@@ -67,6 +68,9 @@ export default {
       this.setShowShoppingCart(false)
       this.setHideFilters(false)
     }
+  },
+  mounted: function () {
+    this.fetchTableViewData({ tableName: this.tableName })
   }
 }
 </script>

--- a/packages/data-explorer/tests/unit/views/ClipboardView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ClipboardView.spec.ts
@@ -20,7 +20,8 @@ describe('ClipboardView.vue', () => {
           { tableID: '2' },
           { tableID: '3' }
         ]
-      }
+      },
+      tableName: 'tableID'
     }
     mutations = {
       setShowShoppingCart: jest.fn(),

--- a/packages/data-explorer/tests/unit/views/ClipboardView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ClipboardView.spec.ts
@@ -9,6 +9,7 @@ describe('ClipboardView.vue', () => {
   let store: any
   let state: any
   let mutations: any
+  let actions: any
 
   beforeEach(() => {
     state = {
@@ -27,7 +28,11 @@ describe('ClipboardView.vue', () => {
       setShowShoppingCart: jest.fn(),
       setHideFilters: jest.fn()
     }
-    store = new Vuex.Store({ state, mutations })
+
+    actions = {
+      fetchTableViewData: jest.fn()
+    }
+    store = new Vuex.Store({ state, mutations, actions })
   })
 
   it('exists', () => {


### PR DESCRIPTION
Load deep data when showing clipboard as refs may be part of row data

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
