### PR TITLE
fix(questionnaires): handle error response

### DIFF
--- a/packages/questionnaires/src/store/actions.js
+++ b/packages/questionnaires/src/store/actions.js
@@ -5,8 +5,12 @@ import type { VuexContext, QuestionnaireType } from '../flow.types.js'
 import Vue from 'vue'
 import { EntityToFormMapper } from '@molgenis/molgenis-ui-form'
 
-const handleError = (commit: Function, error: Error) => {
-  commit('SET_ERROR', error)
+const handleError = (commit: Function, error) => {
+  if (Array.isArray(error.errors)) {
+    commit('SET_ERROR', error.errors[0].message)
+  } else {
+    commit('SET_ERROR', error.message)
+  }
   commit('SET_LOADING', false)
 }
 

--- a/packages/questionnaires/test/unit/specs/store/actions.spec.js
+++ b/packages/questionnaires/test/unit/specs/store/actions.spec.js
@@ -100,13 +100,13 @@ describe('actions', () => {
     })
 
     it('should commit any errors to the store', done => {
-      const error = 'error'
+      const error = { errors: [ { message: 'error' } ] }
       mockApiGetError('/menu/plugins/questionnaires/list', error)
 
       const expectedMutations = [
         {type: 'SET_ERROR', payload: ''},
         {type: 'SET_LOADING', payload: true},
-        {type: 'SET_ERROR', payload: error},
+        {type: 'SET_ERROR', payload: 'error'},
         {type: 'SET_LOADING', payload: false}
       ]
 
@@ -193,13 +193,13 @@ describe('actions', () => {
 
     it('should commit any errors to the store', done => {
       const questionnaireId = 'test_quest'
-      const error = 'error'
+      const error = { errors: [ { message: 'error' } ] }
       mockApiGetError('/menu/plugins/questionnaires/start/test_quest', error)
 
       const expectedMutations = [
         {type: 'SET_ERROR', payload: ''},
         {type: 'SET_LOADING', payload: true},
-        {type: 'SET_ERROR', payload: error},
+        {type: 'SET_ERROR', payload: 'error'},
         {type: 'SET_LOADING', payload: false}
       ]
 
@@ -301,7 +301,7 @@ describe('actions', () => {
 
     it('should commit any errors to the store', done => {
       const questionnaireId = 'other_test_quest'
-      const error = 'error'
+      const error = { errors: [ { message: 'error' } ] }
       const state = {
         username: 'testuser'
       }
@@ -310,7 +310,7 @@ describe('actions', () => {
       const expectedMutations = [
         {type: 'SET_ERROR', payload: ''},
         {type: 'SET_LOADING', payload: true},
-        {type: 'SET_ERROR', payload: error},
+        {type: 'SET_ERROR', payload: 'error'},
         {type: 'SET_LOADING', payload: false}
       ]
 
@@ -377,13 +377,13 @@ describe('actions', () => {
 
     it('should commit any errors to the store', done => {
       const questionnaireId = 'test_quest'
-      const error = 'error'
+      const error = { errors: [ { message: 'error' } ] }
       mockApiGetError('/api/v2/test_quest', error)
 
       const expectedMutations = [
         {type: 'SET_ERROR', payload: ''},
         {type: 'SET_LOADING', payload: true},
-        {type: 'SET_ERROR', payload: error},
+        {type: 'SET_ERROR', payload: 'error'},
         {type: 'SET_LOADING', payload: false}
       ]
 
@@ -409,13 +409,13 @@ describe('actions', () => {
 
     it('should commit any errors to the store', done => {
       const questionnaireId = 'test_quest'
-      const error = 'error'
+      const error = new Error('error')
       mockApiGetError('/menu/plugins/questionnaires/submission-text/test_quest', error)
 
       const expectedMutations = [
         {type: 'SET_ERROR', payload: ''},
         {type: 'SET_LOADING', payload: true},
-        {type: 'SET_ERROR', payload: error},
+        {type: 'SET_ERROR', payload: 'error'},
         {type: 'SET_LOADING', payload: false}
       ]
 


### PR DESCRIPTION
We accidentally upgraded the api client which broke the message alerts.

Fixes #180

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Conventional commits (squash if needed)
- No warnings during install
- Updated javascript typing
