### PR TITLE
chore: bump app versions for backend version: 8.3.0

### DIFF
--- a/docker/proxy-config/proxy.d/frontend/lts.conf
+++ b/docker/proxy-config/proxy.d/frontend/lts.conf
@@ -20,7 +20,7 @@ location /@molgenis-ui/ {
   rewrite ^/(.*)/questionnaires/(.*)$         /$1/questionnaires@2.0.5/$2     break;
   rewrite ^/(.*)/scripts/(.*)$                /$1/scripts@2.0.2/$2            break;
   rewrite ^/(.*)/search-all/(.*)$             /$1/search-all@0.1.4/$2         break;
-  rewrite ^/(.*)/security/(.*)$               /$1/security@0.1.7/$2           break;
+  rewrite ^/(.*)/security/(.*)$               /$1/security@0.2.0/$2           break;
   rewrite ^/(.*)/settings/(.*)$               /$1/settings@2.0.2/$2           break;
 
   proxy_pass https://unpkg.com/@molgenis-ui/;

--- a/docker/proxy-config/proxy.d/frontend/lts.conf
+++ b/docker/proxy-config/proxy.d/frontend/lts.conf
@@ -12,15 +12,15 @@ location /@molgenis-ui/ {
 
   rewrite ^/(.*)/app-manager/(.*)$            /$1/app-manager@0.1.4/$2        break;
   rewrite ^/(.*)/core-ui/(.*)$                /$1/core-ui@0.3.1/$2            break;
-  rewrite ^/(.*)/legacy-lib/(.*)$             /$1/legacy-lib@1.1.1/$2        break;
+  rewrite ^/(.*)/legacy-lib/(.*)$             /$1/legacy-lib@1.1.2/$2        break;
   rewrite ^/(.*)/data-row-edit/(.*)$          /$1/data-row-edit@3.0.3/$2      break;
-  rewrite ^/(.*)/metadata-manager/(.*)$       /$1/metadata-manager@0.1.7/$2   break;
+  rewrite ^/(.*)/metadata-manager/(.*)$       /$1/metadata-manager@0.1.8/$2   break;
   rewrite ^/(.*)/navigator/(.*)$              /$1/navigator@0.1.3/$2          break;
   rewrite ^/(.*)/one-click-importer@/(.*)$    /$1/one-click-importer@0.1.4/$2 break;
   rewrite ^/(.*)/questionnaires/(.*)$         /$1/questionnaires@2.0.5/$2     break;
   rewrite ^/(.*)/scripts/(.*)$                /$1/scripts@2.0.2/$2            break;
   rewrite ^/(.*)/search-all/(.*)$             /$1/search-all@0.1.4/$2         break;
-  rewrite ^/(.*)/security/(.*)$               /$1/security@0.1.6/$2           break;
+  rewrite ^/(.*)/security/(.*)$               /$1/security@0.1.7/$2           break;
   rewrite ^/(.*)/settings/(.*)$               /$1/settings@2.0.2/$2           break;
 
   proxy_pass https://unpkg.com/@molgenis-ui/;


### PR DESCRIPTION
- metadata-manager to 0.1.8 --> [CHANGELOG](https://github.com/molgenis/molgenis-frontend/blob/master/packages/metadata-manager/CHANGELOG.md)
- security-manager to 0.2.0 --> [CHANGELOG](https://github.com/molgenis/molgenis-frontend/blob/master/packages/security/CHANGELOG.md)
- legacy-lib to 1.1.2 --> [CHANGELOG](https://github.com/molgenis/molgenis-frontend/blob/master/packages/legacy-lib/CHANGELOG.md)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
