### PR TITLE
fix(data-explorer: Fix #275 encodeRsql filter string

### DIFF
--- a/packages/data-explorer/src/repository/dataRepository.ts
+++ b/packages/data-explorer/src/repository/dataRepository.ts
@@ -4,6 +4,7 @@ import * as metaDataRepository from './metaDataRepository'
 import { DataApiResponse, DataApiResponseItem, DataObject } from '@/types/ApiResponse'
 import { MetaData, Attribute } from '@/types/MetaData'
 import axios from 'axios'
+import { encodeRsqlValue } from '@molgenis/rsql'
 
 // maps api response to object with as key the name of the column and as value the label of the value or a list of labels for mrefs
 const levelOneRowMapper = async (rowData: DataApiResponseItem, metaData: MetaData) => {
@@ -89,7 +90,7 @@ const levelNRowMapper = (rowData: DataApiResponseItem) => {
 }
 
 const addFilterIfSet = (request: string, rsqlFilter?: string): string => {
-  return rsqlFilter ? `${request}&q=${rsqlFilter}` : request
+  return rsqlFilter ? `${request}&q=${encodeRsqlValue(rsqlFilter)}` : request
 }
 
 const getTableDataDeepReference = async (tableId: string, metaData: MetaData, coloms: string[], rsqlQuery?: string) => {

--- a/packages/data-explorer/tests/unit/repository/dataRepository.spec.ts
+++ b/packages/data-explorer/tests/unit/repository/dataRepository.spec.ts
@@ -36,13 +36,23 @@ describe('dataRepository', () => {
   })
 
   describe('getTableDataWithLabel', () => {
-    it('should fetch the table data and expand the query for the label data ', async () => {
+    beforeEach(() => {
       // @ts-ignore
       axios.get.mockResolvedValue({ data: { items: [
         mockRowResponse
       ] } })
+    })
+
+    it('should fetch the table data and expand the query for the label data ', async (done) => {
       await dataRepository.getTableDataWithLabel('tableId', mockmeta as MetaData, ['foo'])
       expect(axios.get).toBeCalledWith('/api/data/tableId?expand=&filter=foo,id,label')
+      done()
+    })
+
+    it('should url encode the filter values if needed ', async (done) => {
+      await dataRepository.getTableDataWithLabel('tableId', mockmeta as MetaData, ['foo'], 'bloodtype=in=(A-,A+)')
+      expect(axios.get).toBeCalledWith('/api/data/tableId?expand=&filter=foo,id,label&q=bloodtype=in=(A-,A%2B)')
+      done()
     })
   })
 })


### PR DESCRIPTION
Fix #275,  encodeRsql filter string before sending request

closes: #275

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
