### PR TITLE
feat(data-explorer): Add search

### DIFF
--- a/packages/data-explorer/src/components/SearchComponent.vue
+++ b/packages/data-explorer/src/components/SearchComponent.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="input-group mb-3">
+    <input
+      type="text"
+      v-model="searchText"
+      class="form-control"
+      placeholder="Search"
+      aria-label="Search data"
+      aria-describedby="mg-data-explorer-search"
+    />
+    <div class="input-group-append">
+      <button
+        class="btn btn-outline-secondary"
+        type="button"
+        id="mg-data-explorer-search"
+        @click="handleSearchAction"
+      >
+        <font-awesome-icon icon="search"></font-awesome-icon>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faSearch } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+library.add(faSearch)
+
+export default {
+  name: 'SearchComponent',
+  components: { FontAwesomeIcon },
+  props: {
+    value: {
+      type: String,
+      required: false
+    }
+  },
+  data () {
+    return {
+      searchText: this.value
+    }
+  },
+  methods: {
+    handleSearchAction () {
+      this.$emit('input', this.searchText)
+    }
+  },
+  watch: {
+    value: {
+      handler: function (val, oldVal) {
+        if (val === '') {
+          this.searchText = ''
+        }
+      },
+      immediate: true
+    }
+  }
+}
+</script>

--- a/packages/data-explorer/src/mappers/rsqlMapper.ts
+++ b/packages/data-explorer/src/mappers/rsqlMapper.ts
@@ -1,13 +1,13 @@
 import { Operator, ComparisonOperator, Value, Constraint, transformToRSQL } from '@molgenis/rsql'
 import { FilterGroup } from '@/types/ApplicationState'
 
+export const createLikeQuery = (attributeName: string, selection: Value): Constraint => ({ selector: attributeName, comparison: ComparisonOperator.Like, arguments: selection })
 /**
  * Create an RSQL 'in' query for filters
  *
  * @example in query for a country filter
  * country=in=(NL,BE,DE)
  */
-export const createLikeQuery = (attributeName: string, selection: Value): Constraint => ({ selector: attributeName, comparison: ComparisonOperator.Like, arguments: selection })
 export const createInQuery = (attributeName: string, selection: Value[]): Constraint => ({ selector: attributeName, comparison: ComparisonOperator.In, arguments: selection })
 export const createEqualsQuery = (attributeName: string, selection: Value): Constraint => ({ selector: attributeName, comparison: ComparisonOperator.Equals, arguments: selection })
 export const createRangeQuery = (attributeName: string, selection: Value[]): Constraint => ({
@@ -17,6 +17,7 @@ export const createRangeQuery = (attributeName: string, selection: Value[]): Con
     { selector: attributeName, comparison: ComparisonOperator.LesserThanOrEqualTo, arguments: selection[1] }
   ]
 })
+export const createSearchQuery = (selection: Value): Constraint => ({ selector: '*', comparison: ComparisonOperator.Search, arguments: selection })
 /**
  *
  * Transform to RSQL
@@ -25,15 +26,32 @@ export const createRangeQuery = (attributeName: string, selection: Value[]): Con
  * country=in=(NL,BE)
  */
 
-export const createRSQLQuery = (filters: FilterGroup): string | null => {
+export const createRSQLQuery = (filters: FilterGroup, searchText?: string): string | null => {
   const operands: Constraint[] = []
+  let filterDefinitions = filters.definition
+  let filterSelections = filters.selections
 
-  Object.keys(filters.selections).forEach((name: string) => {
-    const selection = filters.selections[name]
+  if (searchText && searchText.length > 0) {
+    filterDefinitions = [...filterDefinitions, {
+      type: 'search-filter',
+      label: 'search',
+      name: '_search',
+      dataType: 'string'
+    }]
+    filterSelections = { ...filters.selections, _search: searchText }
+  }
+
+  Object.keys(filterSelections).forEach((name: string) => {
+    const selection = filterSelections[name]
     if (selection === undefined) return
-    const definition = filters.definition.filter((filter) => filter.name === name)[0]
+    const definition = filterDefinitions.filter((filter) => filter.name === name)[0]
 
     switch (definition.type) {
+      case 'search-filter':
+        if (searchText && searchText.length > 0) {
+          operands.push(createSearchQuery(searchText))
+        }
+        break
       case 'checkbox-filter':
         if (definition.dataType === 'bool') {
           operands.push(createEqualsQuery(name, selection))

--- a/packages/data-explorer/src/mappers/rsqlMapper.ts
+++ b/packages/data-explorer/src/mappers/rsqlMapper.ts
@@ -18,6 +18,7 @@ export const createRangeQuery = (attributeName: string, selection: Value[]): Con
   ]
 })
 export const createSearchQuery = (selection: Value): Constraint => ({ selector: '*', comparison: ComparisonOperator.Search, arguments: selection })
+
 /**
  *
  * Transform to RSQL
@@ -25,7 +26,6 @@ export const createSearchQuery = (selection: Value): Constraint => ({ selector: 
  * @example queries
  * country=in=(NL,BE)
  */
-
 export const createRSQLQuery = (filters: FilterGroup, searchText?: string): string | null => {
   const operands: Constraint[] = []
   let filterDefinitions = filters.definition
@@ -48,9 +48,9 @@ export const createRSQLQuery = (filters: FilterGroup, searchText?: string): stri
 
     switch (definition.type) {
       case 'search-filter':
-        if (searchText && searchText.length > 0) {
-          operands.push(createSearchQuery(searchText))
-        }
+        // search filter case is only added when searchText is non empty, ignore null warning
+        // @ts-ignore
+        operands.push(createSearchQuery(searchText))
         break
       case 'checkbox-filter':
         if (definition.dataType === 'bool') {

--- a/packages/data-explorer/src/store/getters.ts
+++ b/packages/data-explorer/src/store/getters.ts
@@ -3,5 +3,5 @@ import { createRSQLQuery } from '@/mappers/rsqlMapper'
 
 export default {
   filterRsql: (state: ApplicationState): string | null =>
-    state.tableMeta && createRSQLQuery(state.filters)
+    state.tableMeta && createRSQLQuery(state.filters, state.searchText)
 }

--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -88,5 +88,8 @@ export default {
   },
   setIsSettingsLoaded (state: ApplicationState) {
     state.isSettingsLoaded = true
+  },
+  setSearchText (state: ApplicationState, searchText: string) {
+    state.searchText = searchText
   }
 }

--- a/packages/data-explorer/src/store/state.ts
+++ b/packages/data-explorer/src/store/state.ts
@@ -24,7 +24,8 @@ const state: ApplicationState = {
     definition: [],
     shown: [],
     selections: {}
-  }
+  },
+  searchText: ''
 }
 
 export default state

--- a/packages/data-explorer/src/types/ApplicationState.ts
+++ b/packages/data-explorer/src/types/ApplicationState.ts
@@ -63,4 +63,5 @@ export default interface ApplicationState {
   tableSettings: TableSetting
   isSettingsLoaded: boolean
   filters: FilterGroup
+  searchText: string
 }

--- a/packages/data-explorer/src/views/DataView.vue
+++ b/packages/data-explorer/src/views/DataView.vue
@@ -1,12 +1,19 @@
 <template>
   <div class="container-fluid">
     <div class="row">
-      <div class="col-10">
+      <div class="col-3">
         <h1 v-if="tableMeta && tableMeta.label" class="mb-0">{{tableMeta.label}}</h1>
-        <small v-if="tableMeta && tableMeta.description" class="text-secondary"><em>{{tableMeta.description}}</em></small>
       </div>
-      <div class="col-2" v-if="tableName">
-        <table-settings-button class="float-right" :tableSettings="tableSettings"></table-settings-button>
+      <div class="col-6">
+        <search-component v-model="searchText"></search-component>
+      </div>
+      <div class="col-3">
+         <table-settings-button class="float-right" :tableSettings="tableSettings"></table-settings-button>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6">
+               <small v-if="tableMeta && tableMeta.description" class="text-secondary"><em>{{tableMeta.description}}</em></small>
       </div>
     </div>
     <div class="row">
@@ -28,13 +35,22 @@ import Vue from 'vue'
 import ToolbarView from './ToolbarView'
 import SelectLayoutView from './SelectLayoutView'
 import TableSettingsButton from '../components/utils/TableSettingsButton'
+import SearchComponent from '../components/SearchComponent'
 import { mapState, mapActions } from 'vuex'
 import ClipboardView from './ClipboardView'
 
 export default Vue.extend({
   name: 'DataView',
   computed: {
-    ...mapState(['showShoppingCart', 'tableName', 'tableMeta', 'tableSettings'])
+    ...mapState(['showShoppingCart', 'tableName', 'tableMeta', 'tableSettings']),
+    searchText: {
+      get () {
+        return this.$store.state.searchText
+      },
+      set (value) {
+        this.$store.commit('setSearchText', value)
+      }
+    }
   },
   methods: {
     ...mapActions(['getTableSettings'])
@@ -42,6 +58,6 @@ export default Vue.extend({
   created () {
     this.getTableSettings({ tableName: this.tableName })
   },
-  components: { ToolbarView, SelectLayoutView, TableSettingsButton, ClipboardView }
+  components: { ToolbarView, SelectLayoutView, TableSettingsButton, ClipboardView, SearchComponent }
 })
 </script>

--- a/packages/data-explorer/src/views/ToolbarView.vue
+++ b/packages/data-explorer/src/views/ToolbarView.vue
@@ -24,7 +24,7 @@
     <active-filters
       @input="saveFilterState"
       :value="activeFilterSelections"
-      :filters="filterDefinitionsWithSearch"
+      :filters="filterDefinitions"
     ></active-filters>
   </div>
 </template>
@@ -46,7 +46,7 @@ export default Vue.extend({
     activeFilterSelections: (vm) => {
       return vm.searchText ? { ...vm.filters.selections, _search: vm.searchText } : vm.filters.selections
     },
-    filterDefinitionsWithSearch: (vm) => {
+    filterDefinitions: (vm) => {
       const searchDef = {
         type: 'string',
         label: 'search',

--- a/packages/data-explorer/src/views/ToolbarView.vue
+++ b/packages/data-explorer/src/views/ToolbarView.vue
@@ -23,8 +23,8 @@
     </button>
     <active-filters
       @input="saveFilterState"
-      :value="filters.selections"
-      :filters="filters.definition"
+      :value="activeFilterSelections"
+      :filters="filterDefinitionsWithSearch"
     ></active-filters>
   </div>
 </template>
@@ -42,10 +42,21 @@ library.add(faShoppingCart, faTh, faThList, faSlidersH, faStore, faShoppingBag)
 export default Vue.extend({
   name: 'ToolbarView',
   computed: {
-    ...mapState(['dataDisplayLayout', 'hideFilters', 'showShoppingCart', 'tableSettings', 'filters'])
+    ...mapState(['dataDisplayLayout', 'hideFilters', 'showShoppingCart', 'tableSettings', 'filters', 'searchText']),
+    activeFilterSelections: (vm) => {
+      return vm.searchText ? { ...vm.filters.selections, _search: vm.searchText } : vm.filters.selections
+    },
+    filterDefinitionsWithSearch: (vm) => {
+      const searchDef = {
+        type: 'string',
+        label: 'search',
+        name: '_search'
+      }
+      return vm.searchText ? [ ...vm.filters.definition, searchDef ] : vm.filters.definition
+    }
   },
   methods: {
-    ...mapMutations(['setDataDisplayLayout', 'setShowShoppingCart', 'setHideFilters', 'setFilterSelection']),
+    ...mapMutations(['setDataDisplayLayout', 'setShowShoppingCart', 'setHideFilters', 'setFilterSelection', 'setSearchText']),
     toggleDataDisplayLayout () {
       const value = this.dataDisplayLayout === 'TableView' ? 'CardView' : 'TableView'
       this.setDataDisplayLayout(value)
@@ -55,6 +66,9 @@ export default Vue.extend({
       this.setHideFilters(true)
     },
     saveFilterState (newSelections) {
+      if (newSelections['_search'] === undefined) {
+        this.setSearchText('')
+      }
       this.setFilterSelection(newSelections)
     }
   },

--- a/packages/data-explorer/tests/unit/components/SearchComponent.spec.ts
+++ b/packages/data-explorer/tests/unit/components/SearchComponent.spec.ts
@@ -1,0 +1,43 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import SearchComponent from '@/components/SearchComponent.vue'
+
+describe('SearchComponent', () => {
+  let wrapper: Wrapper<SearchComponent>
+
+  beforeEach(() => {
+    wrapper = shallowMount(SearchComponent, { propsData: { value: 'demo' } })
+  })
+
+  it('should render the component', () => {
+    expect(wrapper).toBeDefined()
+  })
+
+  it('should place the passed value in the input', () => {
+    const inputElement = wrapper.find('input').element as HTMLInputElement
+    expect(inputElement.value).toEqual('demo')
+  })
+
+  describe('when the search button is clicked', () => {
+    beforeEach(() => {
+      wrapper.find('button').trigger('click')
+    })
+
+    it('should fire a input event passing the searchText', () => {
+      expect(wrapper.emitted('input')).toBeTruthy()
+      expect(wrapper.emitted('input')[0]).toEqual(['demo'])
+    })
+  })
+
+  describe('when the value prop is changed to empty string', () => {
+    beforeEach(() => {
+      wrapper.setProps({ value: '' })
+    })
+
+    it('should clear the search box', () => {
+      wrapper.vm.$nextTick().then(() => {
+        const inputElement = wrapper.find('input').element as HTMLInputElement
+        expect(inputElement.value).toEqual('')
+      })
+    })
+  })
+})

--- a/packages/data-explorer/tests/unit/components/SearchComponent.spec.ts
+++ b/packages/data-explorer/tests/unit/components/SearchComponent.spec.ts
@@ -2,7 +2,7 @@ import { shallowMount, Wrapper } from '@vue/test-utils'
 import SearchComponent from '@/components/SearchComponent.vue'
 
 describe('SearchComponent', () => {
-  let wrapper: Wrapper<SearchComponent>
+  let wrapper: any
 
   beforeEach(() => {
     wrapper = shallowMount(SearchComponent, { propsData: { value: 'demo' } })

--- a/packages/data-explorer/tests/unit/mappers/rsqlMapper.spec.ts
+++ b/packages/data-explorer/tests/unit/mappers/rsqlMapper.spec.ts
@@ -21,6 +21,15 @@ describe('rsqlMapper', () => {
     })
   })
 
+  describe('createSearchQuery', () => {
+    it('create an search Query', async () => {
+      const selections: Value = 'search term'
+      const query = rsqlMapper.createSearchQuery(selections)
+      const rsql = transformToRSQL(query)
+      expect(rsql).toEqual('*=q=\'search term\'')
+    })
+  })
+
   describe('createRSQLQuery', () => {
     let filterState: FilterGroup = {
       hideSidebar: false,
@@ -29,11 +38,16 @@ describe('rsqlMapper', () => {
       selections: {}
     }
     it('will return null with empty filters', async () => {
-      const rsqlQuery = await rsqlMapper.createRSQLQuery(filterState)
+      const rsqlQuery = rsqlMapper.createRSQLQuery(filterState)
       expect(rsqlQuery).toEqual(null)
     })
 
-    it('will', async (done) => {
+    it('should adds search if optional search term is passed', async () => {
+      const rsqlQuery = rsqlMapper.createRSQLQuery(filterState, 'search-term')
+      expect(rsqlQuery).toEqual('*=q=search-term')
+    })
+
+    it('will create a rsql string from the given filterState', () => {
       filterState.selections = {
         search: 'Hello',
         country: ['DE', 'NL'],
@@ -79,9 +93,8 @@ describe('rsqlMapper', () => {
         type: 'default-filter',
         dataType: 'default'
       })
-      const rsqlQuery = await rsqlMapper.createRSQLQuery(filterState)
+      const rsqlQuery = rsqlMapper.createRSQLQuery(filterState)
       expect(rsqlQuery).toEqual('search=like=Hello;country=in=(DE,NL);age=ge=10;age=le=30;comply==(yes);date=ge=1970-01-01T00:00:00.001Z;date=le=1970-01-01T00:00:00.002Z;xref=in=(bla)')
-      done()
     })
   })
 })

--- a/packages/data-explorer/tests/unit/store/actions.spec.ts
+++ b/packages/data-explorer/tests/unit/store/actions.spec.ts
@@ -261,7 +261,8 @@ describe('actions', () => {
         collapseLimit: 5,
         defaultFilters: []
       },
-      isSettingsLoaded: true
+      isSettingsLoaded: true,
+      searchText: ''
     }
 
     getters = {

--- a/packages/data-explorer/tests/unit/store/mutations.spec.ts
+++ b/packages/data-explorer/tests/unit/store/mutations.spec.ts
@@ -225,4 +225,11 @@ describe('mutations', () => {
       expect(baseAppState.isSettingsLoaded).toEqual(true)
     })
   })
+
+  describe('setSearchText', () => {
+    it('sets searchText to the passes value', () => {
+      mutations.setSearchText(baseAppState, 'test123')
+      expect(baseAppState.searchText).toEqual('test123')
+    })
+  })
 })

--- a/packages/data-explorer/tests/unit/store/mutations.spec.ts
+++ b/packages/data-explorer/tests/unit/store/mutations.spec.ts
@@ -75,7 +75,8 @@ describe('mutations', () => {
         definition: [],
         shown: [],
         selections: {}
-      }
+      },
+      searchText: ''
     }
   })
 

--- a/packages/data-explorer/tests/unit/views/DataView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/DataView.spec.ts
@@ -9,25 +9,41 @@ describe('DataView.vue', () => {
   let state: any
   let getters: any
   let actions: any
+  let mutations: any
 
   beforeEach(() => {
     state = {
-      dataDisplayLayout: 'cards'
+      dataDisplayLayout: 'cards',
+      tableSettings: {}
     }
     getters = {
       activeEntityData: jest.fn()
+    }
+    mutations = {
+      setSearchText: jest.fn()
     }
     actions = {
       getTableData: jest.fn(),
       getTableSettings: jest.fn()
     }
     store = new Vuex.Store({
-      state, getters, actions
+      state, getters, actions, mutations
     })
   })
 
   it('exists', () => {
     const wrapper = shallowMount(DataView, { store, localVue })
     expect(wrapper.exists()).toBeTruthy()
+  })
+
+  describe('when the search text model updates', () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = shallowMount(DataView, { store, localVue })
+      wrapper.setData({ searchText: 'test' })
+    })
+    it('should mutate the value to the store', () => {
+      expect(mutations.setSearchText).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
@@ -41,7 +41,9 @@ describe('ToolbarView.vue', () => {
     mutations = {
       setHideFilters: jest.fn(),
       setDataDisplayLayout: jest.fn(),
-      setShowShoppingCart: jest.fn()
+      setShowShoppingCart: jest.fn(),
+      setFilterSelection: jest.fn(),
+      setSearchText: jest.fn()
     }
     store = new Vuex.Store({
       state, mutations
@@ -78,5 +80,22 @@ describe('ToolbarView.vue', () => {
     button.trigger('click')
     expect(mutations.setShowShoppingCart).toHaveBeenCalledWith(state, true)
     expect(mutations.setHideFilters).toHaveBeenCalledWith(state, true)
+  })
+
+  describe('saveFilterState method', () => {
+    let wrapper:any
+    beforeEach(() => {
+      wrapper = shallowMount(ToolbarView, { store, localVue })
+    })
+    it('should clear the search text if search is not part of the filter', () => {
+      const newSelections = {}
+      wrapper.vm.saveFilterState(newSelections)
+      expect(mutations.setSearchText).toHaveBeenCalled()
+    })
+    it('should not clear the search text if search is part of the filter', () => {
+      const newSelections = { _search: 'mock selection' }
+      wrapper.vm.saveFilterState(newSelections)
+      expect(mutations.setSearchText).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
@@ -83,7 +83,7 @@ describe('ToolbarView.vue', () => {
   })
 
   describe('saveFilterState method', () => {
-    let wrapper:any
+    let wrapper: any
     beforeEach(() => {
       wrapper = shallowMount(ToolbarView, { store, localVue })
     })
@@ -96,6 +96,26 @@ describe('ToolbarView.vue', () => {
       const newSelections = { _search: 'mock selection' }
       wrapper.vm.saveFilterState(newSelections)
       expect(mutations.setSearchText).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the search text is non empty', () => {
+    let wrapper: any
+    beforeEach(() => {
+      store.state.searchText = 'my search'
+      wrapper = shallowMount(ToolbarView, { store, localVue })
+    })
+
+    it('should add search to the active filter selection', () => {
+      expect(wrapper.vm.activeFilterSelections).toEqual({ _search: 'my search' })
+    })
+
+    it('should add search to the active filter selection', () => {
+      expect(wrapper.vm.filterDefinitions).toEqual([{
+        type: 'string',
+        label: 'search',
+        name: '_search'
+      } ])
     })
   })
 })

--- a/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
@@ -35,7 +35,8 @@ describe('ToolbarView.vue', () => {
         definition: [],
         shown: [],
         selections: {}
-      }
+      },
+      searchText: ''
     }
     mutations = {
       setHideFilters: jest.fn(),


### PR DESCRIPTION
- Add search component
- Add search field to state
- Make it work together with the filters

Implementation uses the existing filter framework but adds 'search' filter to the list of filter via de data-explorer. In this way existing active-filter components can be used and existing rsql pipeline can be used. Search filter is a 'string' filter and use special rsql search ( with wild card) operator.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
