### PR TITLE
fix: Cache control is not set for /@molgenis-experimental

### DIFF
--- a/docker/proxy-config/proxy.d/frontend/custom.conf
+++ b/docker/proxy-config/proxy.d/frontend/custom.conf
@@ -3,4 +3,6 @@
 #
 # location /my-app/ {
 #   proxy_pass https://my-domain.ext/my-app/;
+    # (Optional )Do not cache these redirects too long
+    # expires 1h;
 # }

--- a/docker/proxy-config/proxy.d/frontend/experimental.conf
+++ b/docker/proxy-config/proxy.d/frontend/experimental.conf
@@ -3,4 +3,6 @@ location /@molgenis-experimental/ {
   proxy_intercept_errors on;
   recursive_error_pages on;
   error_page 301 302 307 = @handle_redirect;
+  # Do not cache these redirects too long
+  expires 2h;
 }


### PR DESCRIPTION
Closes #287

unpk sets max-age to 1 year, index.html includes cache busting of resources but itself if cached according to reserved headers, if there do not include a shorter cache setting the index is cached and its resources remain fixed ( and cached)

- set expires to 2 hours for experimental ( fixed version )
- add note to custom.conf about expires

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
