### PR TITLE
fix: #267 FILE datatype broken in new forms

### DIFF
--- a/packages/data-row-edit/src/repository/dataRowRepository.js
+++ b/packages/data-row-edit/src/repository/dataRowRepository.js
@@ -12,8 +12,8 @@ const flattenCompounds = (fields) => {
 }
 
 const isFileIncluded = (formData, formFields) => {
-  const allFieds = flattenCompounds(formFields)
-  const fieldsWithFile = allFieds
+  const flattendFields = flattenCompounds(formFields)
+  const fieldsWithFile = flattendFields
     .filter((field) => field.type === 'file')
     .find((field) => typeof formData[field.id] !== 'string')
 
@@ -32,8 +32,8 @@ export const appendToForm = (fields, formData, [key, value]) => {
 
 const buildFormData = (data, fields) => {
   const formData = new FormData()
-  const allFieds = flattenCompounds(fields)
-  Object.entries(data).forEach((pair) => appendToForm(allFieds, formData, pair))
+  const flattendFields = flattenCompounds(fields)
+  Object.entries(data).forEach((pair) => appendToForm(flattendFields, formData, pair))
   return formData
 }
 

--- a/packages/data-row-edit/src/repository/dataRowRepository.js
+++ b/packages/data-row-edit/src/repository/dataRowRepository.js
@@ -1,7 +1,19 @@
 import api from '@molgenis/molgenis-api-client'
 
+const flattenCompounds = (fields) => {
+  return fields.reduce((accum, f) => {
+    if (f.type === 'field-group') {
+      accum = accum.concat(flattenCompounds(f.children))
+    } else {
+      accum.push(f)
+    }
+    return accum
+  }, [])
+}
+
 const isFileIncluded = (formData, formFields) => {
-  const fieldsWithFile = formFields
+  const allFieds = flattenCompounds(formFields)
+  const fieldsWithFile = allFieds
     .filter((field) => field.type === 'file')
     .find((field) => typeof formData[field.id] !== 'string')
 
@@ -20,7 +32,8 @@ export const appendToForm = (fields, formData, [key, value]) => {
 
 const buildFormData = (data, fields) => {
   const formData = new FormData()
-  Object.entries(data).forEach((pair) => appendToForm(fields, formData, pair))
+  const allFieds = flattenCompounds(fields)
+  Object.entries(data).forEach((pair) => appendToForm(allFieds, formData, pair))
   return formData
 }
 

--- a/packages/data-row-edit/test/unit/specs/repository/dataRowRepository.spec.js
+++ b/packages/data-row-edit/test/unit/specs/repository/dataRowRepository.spec.js
@@ -154,8 +154,14 @@ describe('Data row repository', () => {
 
       const formFields = [
         {
-          id: 'e',
-          type: 'file'
+          id: 'comp',
+          type: 'field-group',
+          children: [
+            {
+              id: 'e',
+              type: 'file'
+            }
+          ]
         },
         {
           id: 'f',


### PR DESCRIPTION
Closes #267

- check for file type in compounds

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- Updated javascript typing
