### PR TITLE
Fix/286 react to route change

### DIFF
--- a/packages/data-explorer/src/components/utils/TableSettingsButton.vue
+++ b/packages/data-explorer/src/components/utils/TableSettingsButton.vue
@@ -22,15 +22,19 @@ export default {
   name: 'TableSettingsButton',
   components: { FontAwesomeIcon },
   props: {
-    tableSettings: {
-      type: Object,
+    settingsTableId: {
+      type: String,
       required: true
+    },
+    settingsRowId: {
+      type: String,
+      required: false
     }
   },
   computed: {
     href () {
-      const href = `${SETTINGS_APP_URL}/${this.tableSettings.settingsTable}`
-      return this.tableSettings.settingsRowId ? `${href}/${this.tableSettings.settingsRowId}` : href
+      const href = `${SETTINGS_APP_URL}/${this.settingsTableId}`
+      return this.settingsRowId ? `${href}/${this.settingsRowId}` : href
     }
   }
 }

--- a/packages/data-explorer/src/router.ts
+++ b/packages/data-explorer/src/router.ts
@@ -10,14 +10,16 @@ export default new Router({
   base: process.env.NODE_ENV === 'production' ? packageJson.name : process.env.BASE_URL,
   routes: [
     {
-      path: '/',
-      name: 'root',
-      component: MainView
-    },
-    {
       path: '/:entity',
       name: 'main-view',
       component: MainView
+    },
+    {
+      path: '*',
+      redirect: {
+        name: 'main-view',
+        params: { entity: 'root_hospital_patients' }
+      }
     }
   ]
 })

--- a/packages/data-explorer/src/store/actions.ts
+++ b/packages/data-explorer/src/store/actions.ts
@@ -9,13 +9,16 @@ import * as metaFilterMapper from '@/mappers/metaFilterMapper'
 
 export default {
   fetchTableMeta: tryAction(async ({ commit, state }: { commit: any, state: ApplicationState }, payload: { tableName: string }) => {
+    commit('setTableSettings', {})
+    commit('setMetaData', null)
+    commit('setFilterDefinition', [])
+    commit('setFiltersShown', [])
     try {
-      const response = await api.get(`/api/data/${state.tableSettings.settingsTable}?q=table=="${payload.tableName}"`)
+      const response = await api.get(`/api/data/${state.settingsTable}?q=table=="${payload.tableName}"`)
       commit('setTableSettings', response.items[0].data)
     } catch (e) {
       // Use default table settings if no settings loaded
       commit('setTableSettings', {
-        settingsTable: 'de_dataexplorer_table_settings',
         settingsRowId: null,
         collapseLimit: 5,
         customCardCode: null,

--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -20,9 +20,6 @@ export default {
   setHideFilters (state: ApplicationState, hideFilters: boolean) {
     state.filters.hideSidebar = hideFilters
   },
-  setFiltersShown (state: ApplicationState, shown: string[]) {
-    Vue.set(state.filters, 'shown', shown)
-  },
   setTableName (state: ApplicationState, entity: string) {
     state.tableName = entity
   },
@@ -57,7 +54,6 @@ export default {
     }
     if (isPropSet('default_filters')) {
       state.tableSettings.defaultFilters = tableSettings.default_filters.split(',').map(f => f.trim())
-      state.filters.shown = state.tableSettings.defaultFilters
     }
   },
   setMetaData (state: ApplicationState, metaData: MetaData) {
@@ -66,8 +62,10 @@ export default {
   setFilterSelection (state: ApplicationState, selections: StringMap) {
     Vue.set(state.filters, 'selections', selections)
   },
-  setFilters (state: ApplicationState, { definition, shown }: { definition: FilterDefinition[], shown: string[] }) {
+  setFilterDefinition (state: ApplicationState, definition: FilterDefinition[]) {
     Vue.set(state.filters, 'definition', definition)
+  },
+  setFiltersShown (state: ApplicationState, shown: string[]) {
     Vue.set(state.filters, 'shown', shown)
   },
   updateRowData (state: ApplicationState, { rowId, rowData }: {rowId: string, rowData: StringMap}) {

--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -37,9 +37,6 @@ export default {
       state.shoppedEntityItems.push(id)
     }
   },
-  setTableMetaData (state: ApplicationState, meta: MetaData) {
-    state.tableMeta = meta
-  },
   setTableSettings (state: ApplicationState, tableSettings: StringMap) {
     const isPropSet = (prop: string) => typeof tableSettings[prop] !== 'undefined'
 
@@ -99,8 +96,8 @@ export default {
       }
     })
   },
-  setIsSettingsLoaded (state: ApplicationState) {
-    state.isSettingsLoaded = true
+  setIsSettingsLoaded (state: ApplicationState, isLoaded: boolean) {
+    state.isSettingsLoaded = isLoaded
   },
   setSearchText (state: ApplicationState, searchText: string) {
     state.searchText = searchText

--- a/packages/data-explorer/src/store/state.ts
+++ b/packages/data-explorer/src/store/state.ts
@@ -2,6 +2,7 @@ import ApplicationState from '@/types/ApplicationState'
 
 const state: ApplicationState = {
   toast: null,
+  settingsTable: 'de_dataexplorer_table_settings',
   tableName: null,
   tableData: null,
   tableMeta: null,
@@ -10,7 +11,6 @@ const state: ApplicationState = {
   showShoppingCart: false,
   shoppedEntityItems: [],
   tableSettings: {
-    settingsTable: 'de_dataexplorer_table_settings',
     settingsRowId: null,
     collapseLimit: 5,
     customCardCode: null,

--- a/packages/data-explorer/src/store/state.ts
+++ b/packages/data-explorer/src/store/state.ts
@@ -2,7 +2,7 @@ import ApplicationState from '@/types/ApplicationState'
 
 const state: ApplicationState = {
   toast: null,
-  tableName: 'root_hospital_patients',
+  tableName: null,
   tableData: null,
   tableMeta: null,
   dataDisplayLayout: 'CardView',

--- a/packages/data-explorer/src/types/ApplicationState.ts
+++ b/packages/data-explorer/src/types/ApplicationState.ts
@@ -14,7 +14,6 @@ export type FilterOption = {
 }
 
 export type TableSetting = {
-  settingsTable: string,
   customCardCode: string | null,
   customCardAttrs: string
   settingsRowId: string | null,
@@ -53,6 +52,7 @@ export type FilterGroup = {
 }
 export default interface ApplicationState {
   toast: Toast | null,
+  settingsTable: string,
   dataDisplayLayout: 'CardView' | 'TableView'
   tableName: string | null
   tableData: DataApiResponse | null

--- a/packages/data-explorer/src/views/CardView.vue
+++ b/packages/data-explorer/src/views/CardView.vue
@@ -49,7 +49,7 @@ export default {
       return entity[this.idAttribute.name] ? entity[this.idAttribute.name].toString() : ''
     },
     getEntityLabel (entity) {
-      return this.labelAttribute ? entity[this.labelAttribute.name].toString() : this.getEntityId(entity).toString()
+      return this.labelAttribute && entity[this.labelAttribute.name] ? entity[this.labelAttribute.name].toString() : this.getEntityId(entity).toString()
     },
     isSelected (entity) {
       return this.shoppedEntityItems.includes(this.getEntityId(entity))
@@ -58,6 +58,9 @@ export default {
       this.fetchRowDataLabels({ rowId: this.getEntityId(entity) })
     }
   },
+  /**
+   * Todo temp watch, remove watch when sync is done via url
+   */
   watch: {
     filterRsql: {
       handler: function () {

--- a/packages/data-explorer/src/views/ClipboardView.vue
+++ b/packages/data-explorer/src/views/ClipboardView.vue
@@ -73,9 +73,6 @@ export default {
       this.setShowShoppingCart(false)
       this.setHideFilters(false)
     }
-  },
-  mounted: function () {
-    this.fetchTableViewData({ tableName: this.tableName })
   }
 }
 </script>

--- a/packages/data-explorer/src/views/DataView.vue
+++ b/packages/data-explorer/src/views/DataView.vue
@@ -8,7 +8,10 @@
         <search-component v-model="searchText"></search-component>
       </div>
       <div class="col-3">
-         <table-settings-button class="float-right" :tableSettings="tableSettings"></table-settings-button>
+         <table-settings-button class="float-right"
+         :settingsTableId="settingsTable"
+         :settingsRowId="tableSettings.settingsRowId"
+         ></table-settings-button>
       </div>
     </div>
     <div class="row">
@@ -36,13 +39,13 @@ import ToolbarView from './ToolbarView'
 import SelectLayoutView from './SelectLayoutView'
 import TableSettingsButton from '../components/utils/TableSettingsButton'
 import SearchComponent from '../components/SearchComponent'
-import { mapState, mapActions } from 'vuex'
+import { mapState } from 'vuex'
 import ClipboardView from './ClipboardView'
 
 export default Vue.extend({
   name: 'DataView',
   computed: {
-    ...mapState(['showShoppingCart', 'tableName', 'tableMeta', 'tableSettings']),
+    ...mapState(['showShoppingCart', 'tableName', 'tableMeta', 'settingsTable', 'tableSettings']),
     searchText: {
       get () {
         return this.$store.state.searchText

--- a/packages/data-explorer/src/views/DataView.vue
+++ b/packages/data-explorer/src/views/DataView.vue
@@ -52,9 +52,6 @@ export default Vue.extend({
       }
     }
   },
-  methods: {
-    ...mapActions(['getTableSettings'])
-  },
   components: { ToolbarView, SelectLayoutView, TableSettingsButton, ClipboardView, SearchComponent }
 })
 </script>

--- a/packages/data-explorer/src/views/DataView.vue
+++ b/packages/data-explorer/src/views/DataView.vue
@@ -55,9 +55,6 @@ export default Vue.extend({
   methods: {
     ...mapActions(['getTableSettings'])
   },
-  created () {
-    this.getTableSettings({ tableName: this.tableName })
-  },
   components: { ToolbarView, SelectLayoutView, TableSettingsButton, ClipboardView, SearchComponent }
 })
 </script>

--- a/packages/data-explorer/src/views/FiltersView.vue
+++ b/packages/data-explorer/src/views/FiltersView.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-
     <div>
       <div class="p-0 pl-3 d-flex justify-content-between align-items-center">
         <h2>
@@ -16,7 +15,6 @@
       </div>
       <div class="p-2">
         <filter-container
-          v-if="isFilterDataLoaded"
           v-model="filters.selections"
           :filters="filters.definition"
           :filters-shown="filters.shown"
@@ -43,8 +41,7 @@ export default Vue.extend({
   name: 'FiltersView',
   components: { FilterContainer, FontAwesomeIcon },
   computed: {
-    ...mapState(['filters', 'tableMeta', 'isSettingsLoaded']),
-    isFilterDataLoaded: vm => !!vm.tableMeta && vm.isSettingsLoaded
+    ...mapState(['filters'])
   },
   methods: {
     ...mapMutations([ 'setHideFilters', 'setFiltersShown' ]),

--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -56,19 +56,18 @@ export default Vue.extend({
       'filters',
       'toast',
       'showShoppingCart',
-      'dataDisplayLayout'
+      'dataDisplayLayout',
+      'tableName'
     ])
   },
   methods: {
     ...mapMutations([
       'clearToast',
       'setHideFilters',
-      'setTableName',
-      'tableName'
+      'setTableName'
     ]),
     ...mapActions([
       'deleteRow',
-      'getTableSettings',
       'fetchTableMeta',
       'fetchCardViewData',
       'fetchTableViewData'
@@ -82,7 +81,6 @@ export default Vue.extend({
     },
     async fetchViewData (tableName) {
       if (this.tableName !== tableName) {
-        await this.getTableSettings({ tableName })
         await this.fetchTableMeta({ tableName })
         this.setTableName(tableName)
       }
@@ -104,7 +102,6 @@ export default Vue.extend({
     this.$eventBus.$off('delete-item')
   },
   async beforeRouteUpdate (to, from, next) {
-    console.log('Mainvuew beforeRouteUpdate to:' + to.params.entity)
     await this.fetchViewData(to.params.entity)
     next()
   },

--- a/packages/data-explorer/src/views/SelectLayoutView.vue
+++ b/packages/data-explorer/src/views/SelectLayoutView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-3 entity-table" v-show="tableData && tableData.items && tableData.items.length > 0 && tableMeta">
+  <div class="mt-3 entity-table" v-if="tableMeta && tableData">
     <div v-if="tableData && tableData.items && tableData.items.length === 0" class="alert alert-warning">
       {{ 'dataexplorer_empty_table' | i18n}}
     </div>

--- a/packages/data-explorer/src/views/TableView.vue
+++ b/packages/data-explorer/src/views/TableView.vue
@@ -52,6 +52,9 @@ export default {
       return this.shoppedEntityItems.includes(this.getEntityId(entity))
     }
   },
+  /**
+  * Todo temp watch, remove watch when sync is done via url
+  */
   watch: {
     filterRsql: {
       handler: function () {

--- a/packages/data-explorer/tests/unit/components/dataView/TableRow.spec.ts
+++ b/packages/data-explorer/tests/unit/components/dataView/TableRow.spec.ts
@@ -30,6 +30,7 @@ describe('EntityTableRow.vue', () => {
   it('only renders visible columns', () => {
     const wrapper = shallowMount(TableRow, { propsData: {
       id: 'id',
+      tableName: 'tableName',
       rowData: { name: 'name', title: 'title', content: 'content' },
       visibleColumns: [{ name: 'name' }, { content: 'content' }]
     } })

--- a/packages/data-explorer/tests/unit/components/utils/TableSettingsButton.spec.ts
+++ b/packages/data-explorer/tests/unit/components/utils/TableSettingsButton.spec.ts
@@ -6,7 +6,11 @@ describe('TableSettingsButton.vue', () => {
     let wrapper:any
 
     beforeEach(() => {
-      wrapper = shallowMount(TableSettingsButton, { propsData: { tableSettings: { settingsTable: 'my-settings-table' } } })
+      wrapper = shallowMount(TableSettingsButton, {
+        propsData: {
+          settingsTableId: 'my-settings-table'
+        }
+      })
     })
 
     it('the button should link to datarow plugin in add mode', () => {
@@ -18,7 +22,12 @@ describe('TableSettingsButton.vue', () => {
     let wrapper:any
 
     beforeEach(() => {
-      wrapper = shallowMount(TableSettingsButton, { propsData: { tableSettings: { settingsTable: 'my-settings-table', settingsRowId: 'settings-row-id' } } })
+      wrapper = shallowMount(TableSettingsButton, {
+        propsData: {
+          settingsTableId: 'my-settings-table',
+          settingsRowId: 'settings-row-id'
+        }
+      })
     })
 
     it('the button should link to datarow plugin in edit mode', () => {

--- a/packages/data-explorer/tests/unit/store/actions.spec.ts
+++ b/packages/data-explorer/tests/unit/store/actions.spec.ts
@@ -247,6 +247,7 @@ describe('actions', () => {
   beforeEach(() => {
     state = {
       toast: null,
+      settingsTable: 'de_dataexplorer_table_settings',
       tableName: 'it_emx_datatypes_TypeTest',
       tableData: null,
       tableMeta: null,
@@ -265,7 +266,6 @@ describe('actions', () => {
         settingsRowId: null,
         customCardCode: null,
         customCardAttrs: '',
-        settingsTable: 'de_dataexplorer_table_settings',
         collapseLimit: 5,
         defaultFilters: []
       },

--- a/packages/data-explorer/tests/unit/store/mutations.spec.ts
+++ b/packages/data-explorer/tests/unit/store/mutations.spec.ts
@@ -175,12 +175,6 @@ describe('mutations', () => {
       expect(baseAppState.shoppedEntityItems).toEqual(['item1'])
     })
   })
-  describe('setTableMetaData', () => {
-    it('sets the meta data', () => {
-      mutations.setTableMetaData(baseAppState, entityMetaData)
-      expect(baseAppState.tableMeta).toEqual(entityMetaData)
-    })
-  })
   describe('setTableSettings', () => {
     it('sets the tableSettings', () => {
       mutations.setTableSettings(baseAppState, {
@@ -242,8 +236,8 @@ describe('mutations', () => {
   })
 
   describe('setIsSettingsLoaded', () => {
-    it('sets isSettingsLoaded to treu', () => {
-      mutations.setIsSettingsLoaded(baseAppState)
+    it('sets isSettingsLoaded to bool value passed', () => {
+      mutations.setIsSettingsLoaded(baseAppState, true)
       expect(baseAppState.isSettingsLoaded).toEqual(true)
     })
   })

--- a/packages/data-explorer/tests/unit/store/mutations.spec.ts
+++ b/packages/data-explorer/tests/unit/store/mutations.spec.ts
@@ -53,6 +53,7 @@ describe('mutations', () => {
   beforeEach(() => {
     baseAppState = {
       toast: null,
+      settingsTable: 'de_dataexplorer_table_settings',
       tableName: 'root_hospital_patients',
       tableData: null,
       tableMeta: null,
@@ -61,7 +62,6 @@ describe('mutations', () => {
       showShoppingCart: false,
       shoppedEntityItems: [],
       tableSettings: {
-        settingsTable: 'de_dataexplorer_table_settings',
         settingsRowId: null,
         collapseLimit: 5,
         customCardCode: null,
@@ -194,7 +194,6 @@ describe('mutations', () => {
     it('should keep the defaults if no overrides are passed', () => {
       mutations.setTableSettings(baseAppState, {})
       expect(baseAppState.tableSettings).toEqual({
-        settingsTable: 'de_dataexplorer_table_settings',
         settingsRowId: null,
         collapseLimit: 5,
         customCardCode: null,

--- a/packages/data-explorer/tests/unit/views/DataView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/DataView.spec.ts
@@ -23,8 +23,7 @@ describe('DataView.vue', () => {
       setSearchText: jest.fn()
     }
     actions = {
-      getTableData: jest.fn(),
-      getTableSettings: jest.fn()
+      getTableData: jest.fn()
     }
     store = new Vuex.Store({
       state, getters, actions, mutations

--- a/packages/data-explorer/tests/unit/views/MainView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/MainView.spec.ts
@@ -32,11 +32,18 @@ describe('MainView.vue', () => {
     }
 
     mutations = {
-      setActiveEntity: jest.fn()
+      clearToast: jest.fn(),
+      setHideFilters: jest.fn(),
+      setActiveEntity: jest.fn(),
+      setTableName: jest.fn()
     }
 
     actions = {
-      deleteRow: jest.fn()
+      deleteRow: jest.fn(),
+      getTableSettings: jest.fn(),
+      fetchTableMeta: jest.fn(),
+      fetchCardViewData: jest.fn(),
+      fetchTableViewData: jest.fn()
     }
 
     store = new Vuex.Store({

--- a/packages/data-explorer/tests/unit/views/MainView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/MainView.spec.ts
@@ -25,6 +25,7 @@ describe('MainView.vue', () => {
 
   beforeEach(() => {
     state = {
+      tableName: 'tableName',
       activeEntity: 'it_emx_datatypes_TypeTest',
       filters: {
         hideSidebar: false
@@ -40,7 +41,6 @@ describe('MainView.vue', () => {
 
     actions = {
       deleteRow: jest.fn(),
-      getTableSettings: jest.fn(),
       fetchTableMeta: jest.fn(),
       fetchCardViewData: jest.fn(),
       fetchTableViewData: jest.fn()
@@ -87,6 +87,60 @@ describe('MainView.vue', () => {
       const wrapper = shallowMount(MainView, { store, localVue, mocks })
       wrapper.destroy()
       expect(offSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('fetchViewData', () => {
+    it('if table name is changed, should fetch settings and metaData ', async (done) => {
+      const wrapper = shallowMount(MainView, { store, localVue, mocks })
+      // @ts-ignore
+      await wrapper.vm.fetchViewData('new table name')
+      expect(actions.fetchTableMeta).toHaveBeenCalled()
+      expect(mutations.setTableName).toHaveBeenCalled()
+      done()
+    })
+
+    it('if table name is not changed, should not fetch settings and meta ', async (done) => {
+      const wrapper = shallowMount(MainView, { store, localVue, mocks })
+      actions.fetchTableMeta.mockReset()
+      mutations.setTableName.mockReset()
+      // @ts-ignore
+      await wrapper.vm.fetchViewData('tableName')
+      expect(actions.fetchTableMeta).not.toHaveBeenCalled()
+      expect(mutations.setTableName).not.toHaveBeenCalled()
+      done()
+    })
+
+    it('if selected view is cardView, should fetch card data', async (done) => {
+      store.state.dataDisplayLayout = 'CardView'
+      const wrapper = shallowMount(MainView, { store, localVue, mocks })
+      // @ts-ignore
+      await wrapper.vm.fetchViewData('tableName')
+      expect(actions.fetchCardViewData).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  describe('before route update', () => {
+    it('fetch data before calling next', async (done) => {
+      // @ts-ignore
+      actions.fetchTableViewData.mockResolvedValue()
+      const wrapper = shallowMount(MainView, {
+        store,
+        localVue,
+        mocks
+      })
+      const next = jest.fn()
+      const from = {}
+      const to = {
+        params: {
+          entity: 'entity'
+        }
+      }
+      // @ts-ignore use call to pass vm context
+      await wrapper.vm.$options.beforeRouteUpdate.call(wrapper.vm, to, from, next)
+      expect(next).toHaveBeenCalled()
+      done()
     })
   })
 })

--- a/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
@@ -13,6 +13,7 @@ describe('ToolbarView.vue', () => {
   beforeEach(() => {
     state = {
       toast: null,
+      settingsTable: 'de_dataexplorer_table_settings',
       tableName: 'root_hospital_patients',
       tableData: null,
       tableMeta: null,
@@ -23,7 +24,6 @@ describe('ToolbarView.vue', () => {
       isSettingsLoaded: false,
       tableSettings: {
         defaultFilters: [],
-        settingsTable: 'de_dataexplorer_table_settings',
         settingsRowId: null,
         collapseLimit: 5,
         customCardCode: null,

--- a/packages/data-row-edit/CHANGELOG.md
+++ b/packages/data-row-edit/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.5](https://github.com/molgenis/molgenis-frontend/compare/@molgenis-ui/data-row-edit@3.0.4...@molgenis-ui/data-row-edit@3.0.5) (2020-05-07)
+
+
+### Bug Fixes
+
+* [#267](https://github.com/molgenis/molgenis-frontend/issues/267) FILE datatype broken in new forms ([d81885a](https://github.com/molgenis/molgenis-frontend/commit/d81885a))
+
+
+
+
+
 ## [3.0.4](https://github.com/molgenis/molgenis-frontend/compare/@molgenis-ui/data-row-edit@3.0.3...@molgenis-ui/data-row-edit@3.0.4) (2019-10-02)
 
 **Note:** Version bump only for package @molgenis-ui/data-row-edit

--- a/packages/data-row-edit/package.json
+++ b/packages/data-row-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molgenis-ui/data-row-edit",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "license": "LGPL-3.0",
   "description": "Data row edit",
   "author": "sido <sido@haakma.org>",


### PR DESCRIPTION
fix: #286 react to route change 

Closes #286 

- Cleanup router; single route + catch other route path.
- Add route listener to MainView to react to route changes.
   - Remove all onCreated/onMounted testup code ( replaced my listing to route changes).
- Simplfy get data function ( expect meta to be loaded).
- Sync loading of data, first load Setting and Meta, then load data.
- Add comment to filter watchers, these can be removed once filter is part of route.
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
