### PR TITLE
feat(data-explorer): use molgenis theme

### DIFF
--- a/packages/data-explorer/public/index.html
+++ b/packages/data-explorer/public/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>data-explorer</title>
     <!-- Molgenis stylesheet -->
-    <link rel="stylesheet" href="<%= BASE_URL %>bootstrap-molgenis-blue.min.css">
+    <link rel="stylesheet" href="/css/active-theme.css"">
     <style>
       /* concept 7 styled card -> add to molgenis default style sheet? */
       .flex-filter .card-header {


### PR DESCRIPTION
 use molgenis theme endpoint to fetch current style sheet

- Instead of using the style sheet set at build time, use the active-theme endpoint

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
