### PR TITLE
fix(data-row-edit): Fix validation for field group fields

### DIFF
--- a/packages/data-row-edit/src/components/DataRowEdit.vue
+++ b/packages/data-row-edit/src/components/DataRowEdit.vue
@@ -150,14 +150,12 @@ export default {
         this.showRef = true // hide parent
         this.$refs.refContainer.appendChild(refDataRowEdit.$el) // show child
       },
+      touchField (field) {
+        field.children ? field.children.forEach(this.touchField) : this.formState[field.id].$touched = true
+      },
       async onSubmit () {
-        const formState = this.formState
-        this.formFields
-          .filter(field => field.type !== 'field-group') // field-groups have no validation to show
-          .forEach((field) => {
-            const fieldState = formState[field.id]
-            fieldState.$touched = true // trigger field to show validation result to user
-          })
+        this.formFields.forEach(this.touchField) // validate all fields
+
         if (this.formState.$valid) {
           this.isSaving = true
           try {

--- a/packages/data-row-edit/tests/unit/components/DataRowEdit.spec.ts
+++ b/packages/data-row-edit/tests/unit/components/DataRowEdit.spec.ts
@@ -37,8 +37,11 @@ describe('DataRowEdit.vue', () => {
   let wrapper: any
 
   const mappedCreateData = {
-    formFields: [{id: 'a', type: 'text'}],
-    formData: {a: 'b'},
+    formFields: [
+      {id: 'a', type: 'text'},
+      {id: 'c', type: 'field-group', children: [{id: 'f', type: 'text'}]}
+    ],
+    formData: {a: 'b', c: 'd', f: 'g'},
     formLabel: 'form label'
   }
 
@@ -71,6 +74,9 @@ describe('DataRowEdit.vue', () => {
     formState = {
       $valid: true,
       a: {
+        $touched: false,
+      },
+      f: {
         $touched: false,
       }
     }


### PR DESCRIPTION
Instead of looping though form fields, traverse the field tree ( compounds have children)

Closes #347

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
