### PR TITLE
fix(data-explorer): added a silent option to client so that the user is not burdened seeing missing settingstable.

### DIFF
--- a/packages/data-explorer/src/lib/bootstrapExplorer.ts
+++ b/packages/data-explorer/src/lib/bootstrapExplorer.ts
@@ -6,7 +6,7 @@ const packageEndpoint = 'api/data/sys_md_Package'
 const metaDataEndpoint = 'api/metadata'
 
 async function createSettings () {
-  if (store.getters.hasEditRights) {
+  if (store.getters.hasEditRights === true) {
     store.commit('setToast', { type: 'warning', message: 'Bootstrapping Data explorer' })
     try {
       await silentClient.post(packageEndpoint, applicationSettings.packageSettings)

--- a/packages/data-explorer/src/lib/client.ts
+++ b/packages/data-explorer/src/lib/client.ts
@@ -22,8 +22,8 @@ const client:AxiosInstance = build({
 })
 
 export const silentClient:AxiosInstance = build({
-  responseErrorInterceptor: () => {
-    return Promise.resolve()
+  responseErrorInterceptor: (error) => {
+    return Promise.reject(error)
   }
 })
 

--- a/packages/data-explorer/src/lib/client.ts
+++ b/packages/data-explorer/src/lib/client.ts
@@ -21,4 +21,10 @@ const client:AxiosInstance = build({
   responseErrorInterceptor: errorReponse
 })
 
+export const silentClient:AxiosInstance = build({
+  responseErrorInterceptor: () => {
+    return Promise.resolve()
+  }
+})
+
 export default client

--- a/packages/data-explorer/src/store/actions.ts
+++ b/packages/data-explorer/src/store/actions.ts
@@ -1,4 +1,4 @@
-import client from '@/lib/client'
+import { silentClient } from '@/lib/client'
 import ApplicationState from '@/types/ApplicationState'
 import * as metaDataRepository from '@/repository/metaDataRepository'
 import * as dataRepository from '@/repository/dataRepository'
@@ -16,7 +16,7 @@ export default {
     commit('setSearchText', '')
 
     try {
-      const response = await client.get(`/api/data/${state.settingsTable}?q=table=="${payload.tableName}"`)
+      const response = await silentClient.get(`/api/data/${state.settingsTable}?q=table=="${payload.tableName}"`)
       if (response.data.items.length === 1) {
         commit('setTableSettings', response.data.items[0].data)
       }

--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -86,8 +86,7 @@ export default Vue.extend({
       'deleteRow',
       'fetchTableMeta',
       'fetchCardViewData',
-      'fetchTableViewData',
-      'fetchTableMeta'
+      'fetchTableViewData'
     ]),
     ...mapActions('header', [
       'fetchBreadcrumbs'

--- a/packages/data-explorer/tests/unit/lib/bootstrapExplorer.spec.ts
+++ b/packages/data-explorer/tests/unit/lib/bootstrapExplorer.spec.ts
@@ -1,12 +1,10 @@
 import bootstrapExplorer from '@/lib/bootstrapExplorer'
-import client from '@/lib/client'
+import { silentClient } from '@/lib/client'
 import store from '@/store/store'
 import applicationSettings from '@/lib/applicationSettings'
 
-jest.mock('@/lib/client', () => ({
-  post: jest.fn(),
-  get: jest.fn()
-}))
+silentClient.get = jest.fn()
+silentClient.post = jest.fn()
 
 jest.mock('@/store/store', () => ({
   commit: jest.fn(),
@@ -16,25 +14,25 @@ jest.mock('@/store/store', () => ({
 describe('bootstrapExplorer.ts', () => {
   it('checks if table exists', async (done) => {
     await bootstrapExplorer()
-    expect(client.get).toBeCalledWith('/api/data/app_set_DataExplorerEntitySettings')
+    expect(silentClient.get).toBeCalledWith('/api/data/app_set_DataExplorerEntitySettings')
     done()
   })
   it('only adds data when user has edit rights', async (done) => {
     store.getters.hasEditRights = false
-    client.get = jest.fn(() => {
+    silentClient.get = jest.fn(() => {
       return new Promise((resolve, reject) => reject(new Error()))
     })
 
     await bootstrapExplorer()
-    expect(store.commit).toHaveBeenCalledWith('setToast', { type: 'danger', message: 'Please login as administrator to initialize the application' })
+    expect(store.commit).not.toBeCalled()
     done()
   })
 
   it('adds data if the table does not exist', async (done) => {
     store.getters.hasEditRights = true
     await bootstrapExplorer()
-    expect(client.post).toBeCalledWith('api/data/sys_md_Package', applicationSettings.packageSettings)
-    expect(client.post).toBeCalledWith('api/metadata', applicationSettings.entitySettings)
+    expect(silentClient.post).toBeCalledWith('api/data/sys_md_Package', applicationSettings.packageSettings)
+    expect(silentClient.post).toBeCalledWith('api/metadata', applicationSettings.entitySettings)
     done()
   })
 })


### PR DESCRIPTION
When I don't login, I don't see a toast saying I can't access the settingstable

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
