### PR TITLE
fix: distinguish vue-cli babel preset from rollup preset

### DIFF
--- a/packages/components-library/babel.config.js
+++ b/packages/components-library/babel.config.js
@@ -1,6 +1,9 @@
-
-module.exports = {
-  presets: [
-    ['@babel/preset-env', {modules: false}]
-  ]
+if (process.env.ROLLUP_BUILD) {
+  module.exports = {
+    presets: [['@babel/preset-env', { modules: false }]]
+  }
+} else {
+  module.exports = {
+    presets: [['@vue/app']]
+  }
 }

--- a/packages/components-library/rollup.config.js
+++ b/packages/components-library/rollup.config.js
@@ -7,6 +7,8 @@ import vue from 'rollup-plugin-vue'
 import esbuild from 'rollup-plugin-esbuild'
 import css from 'rollup-plugin-css-only'
 
+process.env.ROLLUP_BUILD=1
+
 const plugins = [
   // Filters inline css from vue files
   css({ output: 'dist/components-library.css' }),


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
