### PR TITLE
Feat/multi filter returns object

### DIFF
--- a/packages/components-library/src/components/filters/MultiFilter.vue
+++ b/packages/components-library/src/components/filters/MultiFilter.vue
@@ -1,28 +1,11 @@
 <template>
   <div>
     <b-input-group>
-      <b-form-input
-        v-model="query"
-        :name="name"
-        :placeholder="placeholder"
-        trim
-      />
+      <b-form-input v-model="query" :name="name" :placeholder="placeholder" trim />
       <b-input-group-append>
-        <b-button
-          variant="outline-secondary"
-          :disabled="isLoading"
-          @click.prevent="query= ''"
-        >
-          <font-awesome-icon
-            v-if="isLoading"
-            icon="spinner"
-            class="fa-spin"
-            size="xs"
-          />
-          <font-awesome-icon
-            v-else
-            icon="times"
-          />
+        <b-button variant="outline-secondary" :disabled="isLoading" @click.prevent="query = ''">
+          <font-awesome-icon v-if="isLoading" icon="spinner" class="fa-spin" size="xs" />
+          <font-awesome-icon v-else icon="times" />
         </b-button>
       </b-input-group-append>
     </b-input-group>
@@ -35,11 +18,7 @@
       stacked
     />
 
-    <b-link
-      v-if="showCount < multifilterOptions.length"
-      class="card-link"
-      @click="showMore"
-    >
+    <b-link v-if="showCount < multifilterOptions.length" class="card-link" @click="showMore">
       {{ showMoreText }}
     </b-link>
     <font-awesome-icon
@@ -207,11 +186,11 @@ export default {
           queryIds = this.value.map(vo => vo.value)
         }
         this.selection = queryIds
-
+        // Get the initial selected
         fetched = await this.options({ nameAttribute: 'label', queryType: 'in', query: queryIds.join(',') })
-      } else {
-        fetched = await this.options({ nameAttribute: 'label', count: this.initialDisplayItems })
       }
+      // fetch the other options and deduplicate (incase of value filled)
+      fetched = [...new Set(fetched.concat(await this.options({ nameAttribute: 'label', count: this.initialDisplayItems })))]
       this.initialOptions = fetched
     }
   }

--- a/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
+++ b/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
@@ -97,4 +97,24 @@ describe('MultiFilter.vue', () => {
     jest.runAllTimers()
     expect(optionsPromise).toHaveBeenCalledWith({ nameAttribute: 'label', query: 'Blue' })
   })
+
+  it('does not emit an input event when value is set from outside the component', async () => {
+    wrapper.setProps({ value: ['orange'] })
+    expect(wrapper.emitted().input).toBeFalsy()
+  })
+
+  describe('prop: returnTypeAsObject', () => {
+    it('should return only the value when falsy [default]', async () => {
+      const checkbox = wrapper.find('input[type=checkbox]').element as HTMLInputElement
+      await checkbox.click()
+      expect(wrapper.emitted().input).toEqual([[['red']]])
+    })
+
+    it('should return the complete option object when true', async () => {
+      wrapper.setProps({ returnTypeAsObject: true })
+      const checkbox = wrapper.find('input[type=checkbox]').element as HTMLInputElement
+      await checkbox.click()
+      expect(wrapper.emitted().input).toEqual([[[{ text: 'Red', value: 'red' }]]])
+    })
+  })
 })


### PR DESCRIPTION
When selecting a filter option return the selected option itself instead of the selected options identifier.

This is needed as the options itself may be lazy loaded.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- User documentation updated
- [ ] Conventional commits (squash if needed)
- No warnings during install
- Updated javascript typing
