### PR TITLE
fix(data-explorer): Fix selecting items with non standerd id / label

### DIFF
--- a/packages/data-explorer/src/store/getters.ts
+++ b/packages/data-explorer/src/store/getters.ts
@@ -1,5 +1,6 @@
 import ApplicationState from '@/types/ApplicationState'
 import { createRSQLQuery } from '@/mappers/rsqlMapper'
+import { ClipBoardItem } from '@/types/ClipBoardItem'
 
 export default {
   filterRsql: (state: ApplicationState): string | null =>
@@ -17,5 +18,31 @@ export default {
   },
   hasEditSettingsRights: (state: ApplicationState, getters: any): boolean => {
     return getters.isUserAuthenticated && getters.userRoles.includes('ROLE_SU')
+  },
+  tableIdAttributeName: (state: ApplicationState): string | undefined => {
+    return state.tableMeta && state.tableMeta.idAttribute ? state.tableMeta.idAttribute.name : undefined
+  },
+  tableLabelAttributeName: (state: ApplicationState): string | undefined => {
+    return state.tableMeta && state.tableMeta.labelAttribute && state.tableMeta.labelAttribute.name ? state.tableMeta.labelAttribute.name : undefined
+  },
+  clipBoardItems: (state: ApplicationState, getters: any): ClipBoardItem[] => {
+    if (!state.tableData || !state.tableData.items) {
+      return []
+    }
+
+    const tableIdAttributeName = getters.tableIdAttributeName
+    const tableLabelAttributeName = getters.tableLabelAttributeName
+
+    return state.tableData.items
+      .filter(item => state.selectedItemIds.includes(item[tableIdAttributeName]))
+      .map(selectedItem => {
+        const clipBoardItem:any = {
+          id: selectedItem[tableIdAttributeName]
+        }
+        if (tableLabelAttributeName) {
+          clipBoardItem.name = selectedItem[tableLabelAttributeName]
+        }
+        return clipBoardItem
+      })
   }
 }

--- a/packages/data-explorer/src/types/ClipBoardItem.ts
+++ b/packages/data-explorer/src/types/ClipBoardItem.ts
@@ -1,0 +1,4 @@
+export type ClipBoardItem = {
+ id: string | number,
+ name?: string | number
+}

--- a/packages/data-explorer/src/views/ClipboardView.vue
+++ b/packages/data-explorer/src/views/ClipboardView.vue
@@ -37,7 +37,7 @@
 <script>
 import TableRow from '../components/dataView/TableRow'
 import TableHeader from '../components/dataView/TableHeader'
-import { mapState, mapMutations, mapActions } from 'vuex'
+import { mapState, mapMutations, mapActions, mapGetters } from 'vuex'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faShoppingBag, faChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -48,9 +48,7 @@ export default {
   components: { TableRow, TableHeader, FontAwesomeIcon },
   computed: {
     ...mapState(['tableMeta', 'selectedItemIds', 'tableData', 'tableName', 'showSelected']),
-    idAttribute () {
-      return this.tableMeta.idAttribute
-    },
+    ...mapGetters(['tableIdAttributeName']),
     entitiesToShow () {
       return this.tableData.items.filter((entity) => this.selectedItemIds.includes(this.getEntityId(entity)))
     },
@@ -65,7 +63,7 @@ export default {
     ...mapActions(['fetchTableViewData']),
     ...mapMutations(['setShowSelected', 'setHideFilters']),
     getEntityId (entity) {
-      return entity[this.idAttribute.name].toString()
+      return entity[this.tableIdAttributeName].toString()
     },
     isSelected (entity) {
       return this.selectedItemIds.includes(this.getEntityId(entity))

--- a/packages/data-explorer/src/views/DataView.vue
+++ b/packages/data-explorer/src/views/DataView.vue
@@ -24,7 +24,7 @@
 import Vue from 'vue'
 import SelectLayoutView from './SelectLayoutView'
 import ClipboardView from './ClipboardView'
-import { mapState, mapMutations } from 'vuex'
+import { mapState, mapMutations, mapGetters } from 'vuex'
 import { CartSelectionToast } from '@molgenis-ui/components-library'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -47,15 +47,10 @@ export default Vue.extend({
       'tableData',
       'tableMeta'
     ]),
-    displayName () {
-      return (this.tableMeta && this.tableMeta.labelAttribute && this.tableMeta.labelAttribute.name) || 'name'
-    },
+    ...mapGetters(['tableLabelAttributeName', 'clipBoardItems']),
     handleSelectionItems: {
       get () {
-        if (this.tableData.items && this.tableData.items.length > 0) {
-          return this.selectedItemIds.map(id => ({ id: id, name: this.tableData.items.find(item => item.id === id)[this.displayName] }))
-        }
-        return []
+        return this.clipBoardItems
       },
       set (value) {
         this.setSelectedItems(value.map(item => item.id))

--- a/packages/data-explorer/tests/unit/store/getters.spec.ts
+++ b/packages/data-explorer/tests/unit/store/getters.spec.ts
@@ -98,4 +98,66 @@ describe('getters', () => {
       expect(getters.hasEditSettingsRights(state, localGetters)).toEqual(true)
     })
   })
+
+  describe('tableIdAttributeName', () => {
+    let state: any = {}
+
+    it('should return undefined if not set', () => {
+      expect(getters.tableIdAttributeName(state)).toEqual(undefined)
+    })
+
+    it('should return name of the id field if set', () => {
+      state = {
+        tableMeta: {
+          idAttribute: {
+            name: 'some-name'
+          }
+        }
+      }
+      expect(getters.tableIdAttributeName(state)).toEqual('some-name')
+    })
+  })
+
+  describe('tableLabelAttributeName', () => {
+    let state: any = {}
+
+    it('should return undefined if not set', () => {
+      expect(getters.tableLabelAttributeName(state)).toEqual(undefined)
+    })
+
+    it('should return name of the label field if set', () => {
+      state = {
+        tableMeta: {
+          labelAttribute: {
+            name: 'some-label'
+          }
+        }
+      }
+      expect(getters.tableLabelAttributeName(state)).toEqual('some-label')
+    })
+  })
+
+  describe('clipBoardItems', () => {
+    let state: any = {}
+
+    it('should return an empty list if table has no items', () => {
+      expect(getters.clipBoardItems(state, {})).toEqual([])
+    })
+
+    it('should return a list of selected items if set', () => {
+      state.tableData = {
+        items: [
+          { colA: 'my-id', colB: 'my-label' }
+        ]
+      }
+      state.selectedItemIds = ['my-id']
+      let localGetters = {
+        tableIdAttributeName: 'colA',
+        tableLabelAttributeName: 'colB'
+      }
+      expect(getters.clipBoardItems(state, localGetters)).toEqual([
+        { id: 'my-id', name: 'my-label' }
+      ])
+    })
+  })
 })

--- a/packages/data-explorer/tests/unit/views/ClipboardView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ClipboardView.spec.ts
@@ -10,6 +10,7 @@ describe('ClipboardView.vue', () => {
   let state: any
   let mutations: any
   let actions: any
+  let getters: any
 
   beforeEach(() => {
     state = {
@@ -55,7 +56,12 @@ describe('ClipboardView.vue', () => {
     actions = {
       fetchTableViewData: jest.fn()
     }
-    store = new Vuex.Store({ state, mutations, actions })
+
+    getters = {
+      tableIdAttributeName: jest.fn()
+    }
+    getters.tableIdAttributeName.mockReturnValue('tableID')
+    store = new Vuex.Store({ state, mutations, actions, getters })
   })
 
   it('exists', () => {

--- a/packages/data-explorer/tests/unit/views/DataView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/DataView.spec.ts
@@ -29,7 +29,10 @@ describe('DataView.vue', () => {
       searchText: ''
     }
     getters = {
-      activeEntityData: jest.fn()
+      activeEntityData: jest.fn(),
+      tableIdAttributeName: jest.fn(),
+      tableLabelAttributeName: jest.fn(),
+      clipBoardItems: jest.fn()
     }
     mutations = {
       setSearchText: jest.fn(),
@@ -72,29 +75,11 @@ describe('DataView.vue', () => {
       expect(mutations.setHideFilters).toHaveBeenCalledWith(state, true)
     })
 
-    it('should find a name to use as display label', () => {
+    it('should add names to display to the items in the shopping cart', () => {
+      getters.clipBoardItems.mockReturnValueOnce([{ name: 'item1', id: '1' }])
       const wrapper = shallowMount(DataView, { store, localVue })
       // @ts-ignore
-      expect(wrapper.vm.displayName).toEqual('name')
-
-      store.state.tableMeta = { labelAttribute: { name: 'label' } }
-      const wrapper2 = shallowMount(DataView, { store, localVue })
-      // @ts-ignore
-      expect(wrapper2.vm.displayName).toEqual('label')
-    })
-
-    it('should add names to display to the items in the shoppingcart', () => {
-      const wrapper = shallowMount(DataView, { store, localVue })
-      // @ts-ignore
-      expect(wrapper.vm.handleSelectionItems).toEqual([])
-
-      store.state.tableMeta = { labelAttribute: { name: 'label' } }
-      store.state.tableData = { items: [{ label: 'item1', id: '1' }, { label: 'item2', id: '2' }] }
-      store.state.selectedItemIds = ['1', '2']
-
-      const wrapper2 = shallowMount(DataView, { store, localVue })
-      // @ts-ignore
-      expect(wrapper2.vm.handleSelectionItems).toEqual([{ name: 'item1', id: '1' }, { name: 'item2', id: '2' }])
+      expect(wrapper.vm.handleSelectionItems).toEqual([{ name: 'item1', id: '1' }])
     })
 
     it('should remove names to display from items before returning them', () => {


### PR DESCRIPTION
fix(data-explorer): Fix selecting items with non standerd id / label

- Use metadata to find id and label columns
- Move finding id, and label and building clipboards items to getters for reuse

This closes #463, #462 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
