### PR TITLE
feat(data-explorer): Use '/theme/style.css' endpoint for styling

### DIFF
--- a/packages/data-explorer/public/index.html
+++ b/packages/data-explorer/public/index.html
@@ -23,7 +23,7 @@
     });
     </script>
     <!-- Molgenis stylesheet -->
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@molgenis-ui/molgenis-theme/dist/themes/mg-molgenis-blue-4.css">
+    <link rel="stylesheet" type="text/css" href="/theme/style.css"">
     <style>
       /* concept 7 styled card -> add to molgenis default style sheet? */
       .flex-filter .card-header {

--- a/packages/data-explorer/public/index.html
+++ b/packages/data-explorer/public/index.html
@@ -23,7 +23,7 @@
     });
     </script>
     <!-- Molgenis stylesheet -->
-    <link rel="stylesheet" type="text/css" href="/theme/style.css"">
+    <link rel="stylesheet" type="text/css" href="/theme/style.css">
     <style>
       /* concept 7 styled card -> add to molgenis default style sheet? */
       .flex-filter .card-header {

--- a/packages/data-explorer/tests/e2e/specs/test.js
+++ b/packages/data-explorer/tests/e2e/specs/test.js
@@ -23,13 +23,13 @@ module.exports = {
       .waitForElementPresent('#app', timeOutDelay)
       .waitForElementPresent('.shopping-button', timeOutDelay)
       .click('.shopping-button')
-      .click('.toast-body button.btn.btn-secondary')
+      .waitForElementPresent('.toast-body .btn-secondary', timeOutDelay)
+      .click('.toast-body .btn-secondary')
       .waitForElementPresent('.cart-order', timeOutDelay)
       .assert.elementNotPresent('.alert.alert-warning')
       .waitForElementPresent('.shopping-button', timeOutDelay)
       .click('.shopping-button')
-      .pause(animationDelay)
-      .waitForElementPresent('.alert.alert-warning', timeOutDelay)
+      .waitForElementPresent('.alert.alert-warning', (timeOutDelay * 2))
       .end()
   },
   'should display custom card': browser => {
@@ -68,8 +68,8 @@ module.exports = {
       .assert.cssClassPresent('.mg-content', 'hidefilters')
       .waitForElementPresent('.btn.show-filters-button', timeOutDelay)
       .click('.btn.show-filters-button')
+      .waitForElementPresent('.btn.hide-filters', timeOutDelay)
       .assert.elementNotPresent('show-filters-button')
-      .assert.cssClassNotPresent('.mg-content', 'hidefilters')
       .end()
   }
 }

--- a/packages/data-explorer/vue.config.js
+++ b/packages/data-explorer/vue.config.js
@@ -51,6 +51,10 @@ module.exports = {
     // Used to proxy a external API server to have someone to talk to during development
     proxy: process.env.NODE_ENV !== 'development' ? undefined : {
       '^/api': apiDevServerProxyConf,
+      '^/theme': {
+        target: PROXY_TARGET,
+        keepOrigin: true
+      },
       '^/files': {
         target: PROXY_TARGET,
         keepOrigin: true

--- a/packages/data-explorer/vue.config.js
+++ b/packages/data-explorer/vue.config.js
@@ -98,6 +98,9 @@ module.exports = {
     },
     // Used as mock in e2e tests
     before: process.env.NODE_ENV !== 'test' ? undefined : function (app) {
+      app.get('/theme/style.css', function (req, res) {
+        res.redirect('https://unpkg.com/@molgenis-ui/molgenis-theme/dist/themes/mg-molgenis-blue-4.css')
+      })
       app.get('/app-ui-context', function (req, res) {
         res.json(require('./tests/e2e/resources/uiContext.js'))
       })

--- a/packages/data-explorer/yarn.lock
+++ b/packages/data-explorer/yarn.lock
@@ -754,10 +754,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@molgenis-ui/components-library@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-1.5.2.tgz#9afb26c85cc06ba05317df3fd51e9b930df1dc6d"
-  integrity sha512-ecvX2i1ZxQRyOGgdAFzmaqzvuFb40A2u3iacLgFYNIZXo0ro0cycv5l/9Tc+O6gq8sGztofuc7TXRRfJlsBGJw==
+"@molgenis-ui/components-library@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-1.6.0.tgz#662f1f071341dc477227f8328af9e62beb5081b2"
+  integrity sha512-TVb4ldLdwVza0T1K73R+rZoOMk1XtnJrPfCYKAeQk78xDWrf2oHzz2UB0O+iaRw8XE5371BBvJ/yZ3Ae6/E42Q==
 
 "@molgenis/molgenis-api-client@^3.1.0", "@molgenis/molgenis-api-client@^3.1.3":
   version "3.1.3"

--- a/packages/data-explorer/yarn.lock
+++ b/packages/data-explorer/yarn.lock
@@ -754,10 +754,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@molgenis-ui/components-library@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-1.5.1.tgz#81e7f18eed43da60b6e0213505b25304b1fffbef"
-  integrity sha512-H+NaJJa0C1d3IoJtkh89iZhDSnCGrx3VuYm+ApzEvQEztDA1USrrnMgjeUxmMCCxjX5iOkycC1G8/xWvfoGefg==
+"@molgenis-ui/components-library@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-1.5.2.tgz#9afb26c85cc06ba05317df3fd51e9b930df1dc6d"
+  integrity sha512-ecvX2i1ZxQRyOGgdAFzmaqzvuFb40A2u3iacLgFYNIZXo0ro0cycv5l/9Tc+O6gq8sGztofuc7TXRRfJlsBGJw==
 
 "@molgenis/molgenis-api-client@^3.1.0", "@molgenis/molgenis-api-client@^3.1.3":
   version "3.1.3"


### PR DESCRIPTION
BREAKING CHANGE: expects backend to serve active theme at '/theme/style.css'

Depends on: https://github.com/molgenis/molgenis/pull/9129

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
