### PR TITLE
fix(data-explorer): Bump table view column width

### DIFF
--- a/packages/data-explorer/src/components/dataView/TableRow.vue
+++ b/packages/data-explorer/src/components/dataView/TableRow.vue
@@ -71,7 +71,7 @@
   * Style row actions
   */
   .mg-data-column {
-    max-width: 8rem;
+    max-width: 32rem;
     overflow: hidden;
   }
   [role="button"]{


### PR DESCRIPTION
- Set dataexplorer column max-width to more sensible default

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
-  User documentation updated
- [x] Conventional commits (squash if needed)
-  No warnings during install
-  Updated javascript typing
