### PR TITLE
fix: Only show description if description is set

### DIFF
--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -14,7 +14,7 @@
             <span id="mainView-headItemTooltipID">
               {{tableMeta.label}}
             </span>
-            <b-tooltip placement='bottom' target="mainView-headItemTooltipID" triggers="hover">
+            <b-tooltip v-if="tableMeta.description" placement='bottom' target="mainView-headItemTooltipID" triggers="hover">
               {{tableMeta.description}}
             </b-tooltip>
           </li>


### PR DESCRIPTION
- Add missing check to showing description tooltip in case user in not signed in
- If the (optional) fields descrition is not set, no tooltip should be added

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
-  User documentation updated
- [x] Conventional commits (squash if needed)
-  No warnings during install
-  Updated javascript typing
