### PR TITLE
fix(data-explorer): set correct components lib version

### DIFF
--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -22,7 +22,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.19",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/vue-fontawesome": "^0.1.6",
-    "@molgenis-ui/components-library": "^2.0.0",
+    "@molgenis-ui/components-library": "^1.6.4",
     "@molgenis/molgenis-api-client": "^3.1.3",
     "@molgenis/molgenis-i18n-js": "^0.2.1",
     "@molgenis/molgenis-ui-context": "^1.6.5",

--- a/packages/data-explorer/yarn.lock
+++ b/packages/data-explorer/yarn.lock
@@ -754,10 +754,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@molgenis-ui/components-library@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-1.6.3.tgz#a97dc7a1f9cdaf7d3220cabdad8038bdb66e056c"
-  integrity sha512-39EAd5iT/+iKNVvZ06CWAMTojmvOiFVe/dNkpMWgJcyqd6SfpYCk9LUGYof6aucphE15Qu2k/p2owguCpiG7/g==
+"@molgenis-ui/components-library@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-1.6.4.tgz#42a299dffa1f3bee034b41566d26f86e1247d47e"
+  integrity sha512-i7YD3R5UkA2z7o60uF1gp0oQ3ldjvabenIGimWr56DGFMsnWc1mPXXdAW7P2SP8vPCT0shNxq10TU9Esy/KXZg==
 
 "@molgenis/molgenis-api-client@^3.1.0", "@molgenis/molgenis-api-client@^3.1.3":
   version "3.1.3"


### PR DESCRIPTION
- lerna  bump component lib version on component lib release ( but does not update the lock file)
- this data explorer should use 1.x version as pagination comp has breaking change

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
