### PR TITLE
fix(data-explorer): Fix issue with lock file

### DIFF
--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -12,7 +12,8 @@
     "lint": "vue-cli-service lint",
     "e2e": "vue-cli-service test:e2e --mode test",
     "unit": "vue-cli-service test:unit",
-    "clean": "vue-cli-service test:unit --clearCache"
+    "clean": "vue-cli-service test:unit --clearCache",
+    "postversion": "vue-cli-service build"
   },
   "files": [
     "dist",

--- a/packages/data-explorer/yarn.lock
+++ b/packages/data-explorer/yarn.lock
@@ -754,10 +754,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@molgenis-ui/components-library@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-2.0.0.tgz#8bbfa0cd8881af2cb632dbb15f75ca89c71703a2"
-  integrity sha512-zQF4hBKOcbdTnC7nai2wsImeDeg3RnvtNCLpP74l6RxGwIpDho5EEAoeCFEVg4irCpyTms262Da48qBpevBBpw==
+"@molgenis-ui/components-library@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@molgenis-ui/components-library/-/components-library-2.0.1.tgz#b9b95082a1589fcf171ea7d84fe18fec6bf24868"
+  integrity sha512-wCsc8MI4+2fX81DiUvD+HuPVKdkKD586lsKJ+zGGd6CleWqc1+IKBFFYLa1sgFfzxDkvNgFSyQwsq/Ls1gMJ/g==
 
 "@molgenis/molgenis-api-client@^3.1.0", "@molgenis/molgenis-api-client@^3.1.3":
   version "3.1.3"


### PR DESCRIPTION
When is new version is released the ci bumps the version in the package json file,
but did not update the lockfile ( and version tags ).
Adding the postversion build test fixes theses issues ( new lockfile gets build)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
