### PR TITLE
chore: workaround for missing yarn.lock on lerna publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,6 +125,7 @@ pipeline {
             steps {
                 container('node') {
                     sh "yarn install"
+                    sh "yarn lerna exec -- yarn install"  // missing yarn.lock workaround, see https://github.com/lerna/lerna/issues/1171
                     sh "yarn lerna bootstrap"
                     sh "yarn lerna run build --scope @molgenis-ui/components-library"
                     sh "yarn lerna run unit"


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
