### PR TITLE
feat: routerstate can now be handled in one place

### DIFF
--- a/packages/data-explorer/src/components/ColumnSelection.vue
+++ b/packages/data-explorer/src/components/ColumnSelection.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="d-flex flex-column">
     <div class="d-flex">
-      <b-link id="selection-toggle" class="toggle-select ml-auto" @click.prevent="toggleAllColumns">
+      <b-link
+        id="selection-toggle"
+        class="toggle-select ml-auto"
+        @click.prevent="toggleAllColumns"
+      >
         <i>{{ toggleSelectText }}</i>
       </b-link>
     </div>
@@ -19,6 +23,7 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
 export default {
   data: function () {
     return {
@@ -38,12 +43,15 @@ export default {
     }
   },
   methods: {
+    ...mapMutations(['persistToRoute']),
     toggleAllColumns () {
-      this.persistToRoute(this.selectAllState ? [] : this.allColumns)
+      const columnsToHide = this.selectAllState ? [] : this.allColumns
+      this.persistToRoute({ hide: columnsToHide.join() })
       this.selectAllState = !this.selectAllState
     },
     modifyHiddenColumns (event) {
       const { checked, value } = event.target
+
       // check if any columns are hidden, else start with an empty array
       let newHiddenColumnList = this.hiddenColumns.length
         ? this.hiddenColumns
@@ -55,15 +63,8 @@ export default {
       } else {
         newHiddenColumnList.push(value)
       }
-      this.persistToRoute(newHiddenColumnList)
-    },
-    persistToRoute (newHiddenColumnList) {
-      this.$router.push({
-        name: this.$router.currentRoute.name,
-        query: {
-          ...this.$route.query,
-          hide: newHiddenColumnList.filter((hc) => hc).join() // use filter, to remove empty remnants
-        }
+      this.persistToRoute({
+        hide: newHiddenColumnList.join()
       })
     }
   }

--- a/packages/data-explorer/src/components/ColumnSelection.vue
+++ b/packages/data-explorer/src/components/ColumnSelection.vue
@@ -46,7 +46,10 @@ export default {
     ...mapMutations(['persistToRoute']),
     toggleAllColumns () {
       const columnsToHide = this.selectAllState ? [] : this.allColumns
-      this.persistToRoute({ hide: columnsToHide.join() })
+      this.persistToRoute({
+        router: this.$router,
+        query: { hide: columnsToHide.join() }
+      })
       this.selectAllState = !this.selectAllState
     },
     modifyHiddenColumns (event) {
@@ -63,8 +66,10 @@ export default {
       } else {
         newHiddenColumnList.push(value)
       }
+
       this.persistToRoute({
-        hide: newHiddenColumnList.join()
+        router: this.$router,
+        query: { hide: newHiddenColumnList.join() }
       })
     }
   }

--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -5,7 +5,6 @@ import { MetaData } from '@/types/MetaData'
 import getters from '@/store/getters'
 import { defaultPagination } from '@/store/state'
 import { RouteQuery } from '@/types/RouteQuery'
-import router from '@/router'
 
 const defaultSettings = {
   settingsRowId: null,
@@ -136,10 +135,13 @@ export default {
   setSearchText (state: ApplicationState, searchText: string) {
     state.searchText = searchText
   },
-  persistToRoute (_, queryChange: any) {
+  persistToRoute (_ : any, routeObject: { router: any, query: any }) {
+    // we have to pass this.$router, if we import it directly in mutations, jest breaks.
+    const { router, query } = routeObject
+
     let mergedRouterObject = {
       ...router.currentRoute.query,
-      ...queryChange
+      ...query
     }
 
     let routerObjectToPersist = {}
@@ -150,7 +152,6 @@ export default {
         routerObjectToPersist[key] = mergedRouterObject[key]
       }
     }
-    console.log(routerObjectToPersist)
 
     router.push({
       name: router.currentRoute.name,

--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -5,6 +5,7 @@ import { MetaData } from '@/types/MetaData'
 import getters from '@/store/getters'
 import { defaultPagination } from '@/store/state'
 import { RouteQuery } from '@/types/RouteQuery'
+import router from '@/router'
 
 const defaultSettings = {
   settingsRowId: null,
@@ -119,7 +120,7 @@ export default {
       }
     })
   },
-  removeRow (state: ApplicationState, { rowId }: {rowId: string}) {
+  removeRow (state: ApplicationState, { rowId }: { rowId: string }) {
     if (!state.tableData) {
       throw new Error('Cannot delete item from empty table')
     }
@@ -134,5 +135,26 @@ export default {
   },
   setSearchText (state: ApplicationState, searchText: string) {
     state.searchText = searchText
+  },
+  persistToRoute (_, queryChange: any) {
+    let mergedRouterObject = {
+      ...router.currentRoute.query,
+      ...queryChange
+    }
+
+    let routerObjectToPersist = {}
+
+    // remove empty parameters
+    for (const key in mergedRouterObject) {
+      if (mergedRouterObject[key]) {
+        routerObjectToPersist[key] = mergedRouterObject[key]
+      }
+    }
+    console.log(routerObjectToPersist)
+
+    router.push({
+      name: router.currentRoute.name,
+      query: routerObjectToPersist
+    }, () => { }) // fix for duplicate route.
   }
 }

--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -73,10 +73,7 @@ export default Vue.extend({
         return this.$store.state.tablePagination
       },
       set: function (value) {
-        this.$router.push({
-          name: 'main-view',
-          query: { ...this.$route.query, page: value.page, size: value.size }
-        })
+        this.persistToRoute({ page: value.page, size: value.size })
       }
     },
     toasts: {
@@ -124,7 +121,8 @@ export default Vue.extend({
       'setSearchText',
       'setFilterSelection',
       'setDataDisplayLayout',
-      'setRouteQuery'
+      'setRouteQuery',
+      'persistToRoute'
     ]),
     ...mapActions([
       'deleteRow',

--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -121,8 +121,7 @@ export default Vue.extend({
       'setSearchText',
       'setFilterSelection',
       'setDataDisplayLayout',
-      'setRouteQuery',
-      'persistToRoute'
+      'setRouteQuery'
     ]),
     ...mapActions([
       'deleteRow',

--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -73,7 +73,10 @@ export default Vue.extend({
         return this.$store.state.tablePagination
       },
       set: function (value) {
-        this.persistToRoute({ page: value.page, size: value.size })
+        this.$router.push({
+          name: 'main-view',
+          query: { ...this.$route.query, page: value.page, size: value.size }
+        })
       }
     },
     toasts: {

--- a/packages/data-explorer/tests/unit/components/ColumnSelection.spec.ts
+++ b/packages/data-explorer/tests/unit/components/ColumnSelection.spec.ts
@@ -54,7 +54,10 @@ describe('ColumnSelection Component', () => {
     })
     options = {
       store,
-      localVue
+      localVue,
+      mocks: {
+        $router: 'mockRouter'
+      }
     }
     wrapper = mount(ColumnSelection, options)
   })
@@ -74,7 +77,7 @@ describe('ColumnSelection Component', () => {
     inputToTest.trigger('click')
 
     // argument #1 is expect.anything() because it's the injected state.
-    expect(mockPersistToState).toHaveBeenCalledWith(expect.anything(), { 'hide': 'id' })
+    expect(mockPersistToState).toHaveBeenCalledWith(expect.anything(), { router: 'mockRouter', query: { 'hide': 'id' } })
   })
 
   it('emits a router change without the value when input is re-selected', () => {
@@ -82,19 +85,19 @@ describe('ColumnSelection Component', () => {
     inputToTest.trigger('click')
     inputToTest.trigger('click')
 
-    expect(mockPersistToState).toHaveBeenLastCalledWith(expect.anything(), { 'hide': '' })
+    expect(mockPersistToState).toHaveBeenLastCalledWith(expect.anything(), { router: 'mockRouter', query: { 'hide': '' } })
   })
 
   it('emits a router change with all columns when deselect all is clicked', () => {
     const inputToTest = wrapper.find('#selection-toggle')
     inputToTest.trigger('click')
-    expect(mockPersistToState).toHaveBeenCalledWith(expect.anything(), { 'hide': 'id,bool,html,string' })
+    expect(mockPersistToState).toHaveBeenCalledWith(expect.anything(), { router: 'mockRouter', query: { 'hide': 'id,bool,html,string' } })
   })
 
   it('emits a router change with no columns when select all is clicked', async () => {
     const inputToTest = wrapper.find('#selection-toggle')
     await inputToTest.trigger('click') // deselect first
     await inputToTest.trigger('click')
-    expect(mockPersistToState).toHaveBeenLastCalledWith(expect.anything(), { 'hide': '' })
+    expect(mockPersistToState).toHaveBeenLastCalledWith(expect.anything(), { router: 'mockRouter', query: { 'hide': '' } })
   })
 })

--- a/packages/data-explorer/tests/unit/components/ColumnSelection.spec.ts
+++ b/packages/data-explorer/tests/unit/components/ColumnSelection.spec.ts
@@ -2,27 +2,22 @@ import { mount, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
 import bootstrapVue from 'bootstrap-vue'
 import ColumnSelection from '@/components/ColumnSelection.vue'
-import VueRouter from 'vue-router'
 
 const localVue = createLocalVue()
 localVue.use(Vuex)
-localVue.use(VueRouter)
 localVue.use(bootstrapVue)
 
 let store: any
 let options: any
 
-let mockRouterPush: any
-const router = new VueRouter()
-
+let mockPersistToState: any
 let expectedInputCount: number
 let wrapper: any
 
 describe('ColumnSelection Component', () => {
   beforeEach(() => {
     expectedInputCount = 4
-    mockRouterPush = jest.fn()
-    router.push = mockRouterPush
+    mockPersistToState = jest.fn()
 
     store = new Vuex.Store({
       state: {
@@ -52,12 +47,14 @@ describe('ColumnSelection Component', () => {
           ]
         },
         hiddenColumns: []
+      },
+      mutations: {
+        persistToRoute: mockPersistToState
       }
     })
     options = {
       store,
-      localVue,
-      router
+      localVue
     }
     wrapper = mount(ColumnSelection, options)
   })
@@ -76,7 +73,8 @@ describe('ColumnSelection Component', () => {
     const inputToTest = wrapper.find('input[value="id"]')
     inputToTest.trigger('click')
 
-    expect(mockRouterPush).toHaveBeenCalledWith({ 'name': null, 'query': { 'hide': 'id' } })
+    // argument #1 is expect.anything() because it's the injected state.
+    expect(mockPersistToState).toHaveBeenCalledWith(expect.anything(), { 'hide': 'id' })
   })
 
   it('emits a router change without the value when input is re-selected', () => {
@@ -84,19 +82,19 @@ describe('ColumnSelection Component', () => {
     inputToTest.trigger('click')
     inputToTest.trigger('click')
 
-    expect(mockRouterPush).toHaveBeenLastCalledWith({ 'name': null, 'query': { 'hide': '' } })
+    expect(mockPersistToState).toHaveBeenLastCalledWith(expect.anything(), { 'hide': '' })
   })
 
   it('emits a router change with all columns when deselect all is clicked', () => {
     const inputToTest = wrapper.find('#selection-toggle')
     inputToTest.trigger('click')
-    expect(mockRouterPush).toHaveBeenCalledWith({ 'name': null, 'query': { 'hide': 'id,bool,html,string' } })
+    expect(mockPersistToState).toHaveBeenCalledWith(expect.anything(), { 'hide': 'id,bool,html,string' })
   })
 
   it('emits a router change with no columns when select all is clicked', async () => {
     const inputToTest = wrapper.find('#selection-toggle')
     await inputToTest.trigger('click') // deselect first
     await inputToTest.trigger('click')
-    expect(mockRouterPush).toHaveBeenLastCalledWith({ 'name': null, 'query': { hide: '' } })
+    expect(mockPersistToState).toHaveBeenLastCalledWith(expect.anything(), { 'hide': '' })
   })
 })

--- a/packages/data-explorer/tests/unit/store/mutations.spec.ts
+++ b/packages/data-explorer/tests/unit/store/mutations.spec.ts
@@ -302,4 +302,17 @@ describe('mutations', () => {
       expect(baseAppState.hiddenColumns).toEqual(['a', 'b', 'c'])
     })
   })
+
+  describe('persistToState', () => {
+    const mockPush = jest.fn()
+    const mockRouter = {
+      push: mockPush,
+      currentRoute: {
+        name: 'main-view',
+        query: {}
+      }
+    }
+    mutations.persistToRoute(baseAppState, { router: mockRouter, query: { hide: 'id' } })
+    expect(mockPush).toHaveBeenCalledWith({ 'name': 'main-view', 'query': { 'hide': 'id' } }, expect.anything())
+  })
 })


### PR DESCRIPTION
feat: routerstate can now be handled in one place, so we can also remove 'empty' filters from the url.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
