### PR TITLE
feat(data-explorer): Fine grained table permissions

### DIFF
--- a/packages/data-explorer/src/store/actions.ts
+++ b/packages/data-explorer/src/store/actions.ts
@@ -166,6 +166,8 @@ export default {
 
   fetchTablePermissions: async ({ commit }: { commit: any }, payload: { tableName: string }) => {
     const res = await client.get<V2Response>(`/api/v2/${payload.tableName}?start=0&num=0`)
-    commit('setTablePermissions', res.data.meta.permissions)
+    const tablePermissions = res.data.meta.permissions
+    commit('setTablePermissions', tablePermissions)
+    return tablePermissions
   }
 }

--- a/packages/data-explorer/src/store/actions.ts
+++ b/packages/data-explorer/src/store/actions.ts
@@ -1,5 +1,6 @@
 import client from '@/lib/client'
 import ApplicationState from '@/types/ApplicationState'
+import { V2Response } from '@/types/EntityTypeV2'
 import * as metaDataRepository from '@/repository/metaDataRepository'
 import * as dataRepository from '@/repository/dataRepository'
 import * as metaDataService from '@/repository/metaDataService'
@@ -161,5 +162,10 @@ export default {
         clearInterval(interval)
       }
     }, 1000)
+  },
+
+  fetchTablePermissions: async ({ commit }: { commit: any }, payload: { tableName: string }) => {
+    const res = await client.get<V2Response>(`/api/v2/${payload.tableName}?start=0&num=0`)
+    commit('setTablePermissions', res.data.meta.permissions)
   }
 }

--- a/packages/data-explorer/src/store/getters.ts
+++ b/packages/data-explorer/src/store/getters.ts
@@ -15,10 +15,11 @@ export default {
   isUserAuthenticated: (state: ApplicationState, getters: any, rootState:any): boolean => {
     return rootState.account.context ? rootState.account.context.authenticated : false
   },
-  hasEditRights: (state: ApplicationState, getters: any): boolean => {
-    return getters.isUserAuthenticated && getters.userRoles.some((role: string) => {
-      return ['ROLE_EDITOR', 'ROLE_MANAGER', 'ROLE_SU'].includes(role)
-    })
+  hasEditRights: (state: ApplicationState): boolean => {
+    return state.tablePermissions.includes('UPDATE_DATA')
+  },
+  hasAddRights: (state: ApplicationState): boolean => {
+    return state.tablePermissions.includes('ADD_DATA')
   },
   hasEditSettingsRights: (state: ApplicationState, getters: any): boolean => {
     return getters.isUserAuthenticated && getters.userRoles.includes('ROLE_SU')

--- a/packages/data-explorer/src/store/mutations.ts
+++ b/packages/data-explorer/src/store/mutations.ts
@@ -161,5 +161,8 @@ export default {
       name: router.currentRoute.name,
       query: routerObjectToPersist
     }, () => { }) // fix for duplicate route.
+  },
+  setTablePermissions (state: ApplicationState, permissions: string []) {
+    Vue.set(state, 'tablePermissions', permissions)
   }
 }

--- a/packages/data-explorer/src/store/state.ts
+++ b/packages/data-explorer/src/store/state.ts
@@ -9,6 +9,7 @@ const state: ApplicationState = {
   tableName: null,
   tableData: null,
   tableMeta: null,
+  tablePermissions: [],
   tablePagination: { ...defaultPagination },
   dataDisplayLayout: 'CardView',
   defaultEntityData: null,

--- a/packages/data-explorer/src/types/ApplicationState.ts
+++ b/packages/data-explorer/src/types/ApplicationState.ts
@@ -62,6 +62,7 @@ export default interface ApplicationState {
   tableName: string | null
   tableData: DataApiResponse | null
   tableMeta: MetaData | null
+  tablePermissions: string []
   tablePagination: Pagination
   defaultEntityData: DataApiResponseItem[] | null
   selectedItemIds: string[]

--- a/packages/data-explorer/src/types/EntityTypeV2.ts
+++ b/packages/data-explorer/src/types/EntityTypeV2.ts
@@ -1,0 +1,5 @@
+export type V2Response = {
+  meta: {
+    permissions: string[]
+  }
+}

--- a/packages/data-explorer/src/views/MainView.vue
+++ b/packages/data-explorer/src/views/MainView.vue
@@ -105,7 +105,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapMutations(['setTableName', 'setToasts', 'setSearchText', 'setFilterSelection', 'setDataDisplayLayout', 'setRouteQuery']),
-    ...mapActions(['deleteRow', 'fetchViewData', 'fetchTableMeta']),
+    ...mapActions(['deleteRow', 'fetchViewData', 'fetchTableMeta', 'fetchTablePermissions']),
     ...mapActions('header', ['fetchPackageTables']),
     saveFilterState (newSelections) {
       if (newSelections['_search'] === undefined) {
@@ -135,7 +135,9 @@ export default Vue.extend({
     this.$eventBus.$on('delete-item', (data) => {
       this.handeldeleteItem(data)
     })
-    await this.fetchTableMeta({ tableName: this.$route.params.entity })
+    const tableName = this.$route.params.entity
+    this.fetchTablePermissions({ tableName })
+    await this.fetchTableMeta({ tableName })
     this.setRouteQuery(this.$route.query)
     this.setDataDisplayLayout(this.$route.params.view)
     this.fetchViewData()
@@ -145,7 +147,9 @@ export default Vue.extend({
   },
   async beforeRouteUpdate (to, from, next) {
     if (to.params.entity !== from.params.entity) {
-      await this.fetchTableMeta({ tableName: to.params.entity })
+      const tableName = to.params.entity
+      this.fetchTablePermissions({ tableName })
+      await this.fetchTableMeta({ tableName })
     }
     this.setRouteQuery(to.query)
     this.setDataDisplayLayout(to.params.view)

--- a/packages/data-explorer/src/views/ToolbarView.vue
+++ b/packages/data-explorer/src/views/ToolbarView.vue
@@ -7,7 +7,7 @@
       aria-label="Row actions group"
     >
       <a
-        v-if="hasEditRights"
+        v-if="hasAddRights"
         role="button"
         class="btn btn-outline-secondary add-row"
         :href="'/plugin/data-row-edit/' + tableName"
@@ -138,7 +138,7 @@ export default {
       'sort'
     ]),
     ...mapGetters([
-      'hasEditRights',
+      'hasAddRights',
       'hasEditSettingsRights',
       'compressedRouteFilter'
     ]),

--- a/packages/data-explorer/tests/unit/store/actions.spec.ts
+++ b/packages/data-explorer/tests/unit/store/actions.spec.ts
@@ -221,7 +221,14 @@ const mockResponses: {[key:string]: Object} = {
   '/api/v2/entity?num=0': metaResponse,
   '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithOutSettings"': { data: { items: [] } },
   '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithSettings"': { data: { items: [{ data: { id: 'ent-set', shop: true, collapse_limit: 5 } }] } },
-  '/api/data/sys_ts_DataExplorerEntitySettings': {}
+  '/api/data/sys_ts_DataExplorerEntitySettings': {},
+  '/api/v2/my-table?start=0&num=0': {
+    data: {
+      meta: {
+        permissions: ['PERM_A']
+      }
+    }
+  }
 }
 
 const mockPostResponses = {
@@ -240,7 +247,7 @@ jest.mock('@/lib/client', () => {
     get: (url: string) => {
       const mockResp = mockResponses[url]
       if (!mockResp) {
-        console.warn(`mock url (${url}) called but not found in ${mockResponses}`)
+        console.warn(`mock url (${url}) called but not found in ${JSON.stringify(mockResponses, null, 4)}`)
       }
       return Promise.resolve(mockResp)
     },
@@ -546,6 +553,13 @@ describe('actions', () => {
       expect(commit).toHaveBeenCalledTimes(2)
       expect(commit).nthCalledWith(1, 'addToast', { message: 'failed', type: 'info' })
       expect(commit).nthCalledWith(2, 'addToast', { message: 'failed', type: 'danger', timeout: 0 })
+    })
+  })
+
+  describe('fetchTablePermissions', () => {
+    it('fetch the permissions for the given table', async () => {
+      await actions.fetchTablePermissions({ commit }, {tableName: 'my-table'})
+      expect(commit).toHaveBeenCalledWith('setTablePermissions', ['PERM_A'])
     })
   })
 })

--- a/packages/data-explorer/tests/unit/store/getters.spec.ts
+++ b/packages/data-explorer/tests/unit/store/getters.spec.ts
@@ -64,26 +64,30 @@ describe('getters', () => {
   })
 
   describe('hasEditRights', () => {
-    let state: any
+    let state: any = {}
+    state.tablePermissions = []
 
-    it('should return false if not authenticated', () => {
-      let localGetters = {
-        isUserAuthenticated: false,
-        userRoles: []
-      }
-      expect(getters.hasEditRights(state, localGetters)).toEqual(false)
+    it('should return false user does not have update rights', () => {
+      expect(getters.hasEditRights(state)).toEqual(false)
     })
 
-    it('should return true if authenticated and has edit role', () => {
-      let localGetters = {
-        isUserAuthenticated: true,
-        userRoles: ['ROLE_EDITOR']
-      }
-      expect(getters.hasEditRights(state, localGetters)).toEqual(true)
-      localGetters.userRoles = ['ROLE_MANAGER']
-      expect(getters.hasEditRights(state, localGetters)).toEqual(true)
-      localGetters.userRoles = ['ROLE_SU']
-      expect(getters.hasEditRights(state, localGetters)).toEqual(true)
+    it('should return true if authenticated and has edit rights', () => {
+      state.tablePermissions = ['UPDATE_DATA']
+      expect(getters.hasEditRights(state)).toEqual(true)
+    })
+  })
+
+  describe('hasAddRights', () => {
+    let state: any = {}
+    state.tablePermissions = []
+
+    it('should return false user does not have add rights', () => {
+      expect(getters.hasAddRights(state)).toEqual(false)
+    })
+
+    it('should return true if authenticated and has add rights', () => {
+      state.tablePermissions = ['ADD_DATA']
+      expect(getters.hasAddRights(state)).toEqual(true)
     })
   })
 

--- a/packages/data-explorer/tests/unit/store/mutations.spec.ts
+++ b/packages/data-explorer/tests/unit/store/mutations.spec.ts
@@ -315,4 +315,11 @@ describe('mutations', () => {
     mutations.persistToRoute(baseAppState, { router: mockRouter, query: { hide: 'id' } })
     expect(mockPush).toHaveBeenCalledWith({ 'name': 'main-view', 'query': { 'hide': 'id' } }, expect.anything())
   })
+
+  describe('setTablePermissions', () => {
+    it('sets permissions on the store', () => {
+      mutations.setTablePermissions(baseAppState, ['PERM_A', 'PERM_B'])
+      expect(baseAppState.tablePermissions).toEqual(['PERM_A', 'PERM_B'])
+    })
+  })
 })

--- a/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
+++ b/packages/data-explorer/tests/unit/views/ToolbarView.spec.ts
@@ -42,6 +42,7 @@ describe('ToolbarView.vue', () => {
 
     getters = {
       hasEditRights: jest.fn(),
+      hasAddRights: jest.fn(),
       hasEditSettingsRights: jest.fn(),
       compressedRouteFilter: jest.fn()
     }
@@ -102,7 +103,7 @@ describe('ToolbarView.vue', () => {
   })
 
   describe('add row button', () => {
-    beforeEach(() => getters.hasEditRights.mockReturnValueOnce(true))
+    beforeEach(() => getters.hasAddRights.mockReturnValueOnce(true))
 
     it('should render the add button as a link to the data-row-edit', () => {
       const wrapper = shallowMount(ToolbarView, { store, localVue, directives, mocks })


### PR DESCRIPTION
Use v2 api to fetch table permissons
Add/Edit buttons are show depending on table permissions

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x ] Conventional commits (squash if needed)
- No warnings during install
- Updated javascript typing
