### PR TITLE
fix(data-explorer): Remove spinner on error

### DIFF
--- a/packages/data-explorer/src/lib/client.ts
+++ b/packages/data-explorer/src/lib/client.ts
@@ -12,6 +12,7 @@ export const errorReponse = (error: any) => {
       window.location.href = '/login'
     }
   }
+  store.commit('setLoading', false)
   // Set timeout to '0' to keep visible until user dismisses the error notification
   store.commit('addToast', { message, type: 'danger', timeout: 0 })
   return Promise.reject(error)

--- a/packages/data-explorer/src/store/actions.ts
+++ b/packages/data-explorer/src/store/actions.ts
@@ -36,13 +36,11 @@ export default {
   fetchCardViewData: async ({ commit, state, getters }: { commit: any, state: ApplicationState, getters: any }) => {
     if (state.tableName === null) {
       commit('addToast', { message: 'cannot load card data without table name', type: 'danger' })
-      commit('setLoading', false)
       return
     }
 
     if (state.tableMeta === null) {
       commit('addToast', { message: 'cannot load card data without meta data', type: 'danger' })
-      commit('setLoading', false)
       return
     }
 
@@ -75,13 +73,11 @@ export default {
   fetchTableViewData: async ({ commit, state, getters }: { commit: any, state: ApplicationState, getters: any }) => {
     if (state.tableName === null) {
       commit('addToast', { message: 'cannot fetch table view data without table name', type: 'danger' })
-      commit('setLoading', false)
       return
     }
 
     if (state.tableMeta === null) {
       commit('addToast', { message: 'cannot fetch table view data without meta data', type: 'danger' })
-      commit('setLoading', false)
       return
     }
 

--- a/packages/data-explorer/tests/unit/lib/client.spec.ts
+++ b/packages/data-explorer/tests/unit/lib/client.spec.ts
@@ -28,13 +28,14 @@ describe('client', () => {
     expect(window.location.href).toBe('/login')
   })
 
-  it('should do error handling via store addToast', async () => {
+  it('should do error handling via store addToast and remove the spinner', async () => {
     const data = { response: { status: 404, data: { detail: 'world not found' } } }
     try {
       await errorReponse(data)
     } catch (e) {
       expect(e).toBe(data)
     }
+    expect(store.commit).toBeCalledWith('setLoading', false)
     expect(store.commit).toBeCalledWith('addToast', { message: 'world not found', type: 'danger', timeout: 0 })
   })
 


### PR DESCRIPTION
Closes #555

Remove the spinner when an error occurs 
Delete removing spinner in actions, no need to do this, this is handled by the caller

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
