### PR TITLE
fix(data-explorer): Use query if set

### DIFF
--- a/packages/data-explorer/src/components/dataView/DefaultCardContent.vue
+++ b/packages/data-explorer/src/components/dataView/DefaultCardContent.vue
@@ -43,7 +43,7 @@
             <font-awesome-icon v-if="cardState==='open'" icon="chevron-up" />
             <font-awesome-icon v-if="cardState==='closed'" icon="chevron-right" /> {{ expandBtnText }}
           </button>
-          <router-link class="btn btn-outline-info btn-sm mg-info-btn" role="button" :to="{ name: 'entity-detail', params: { entityType: dataTable, entity: dataId}}">
+          <router-link class="btn btn-outline-info btn-sm mg-info-btn" role="button" :to="{ name: 'entity-detail', params: { entityType: dataTable, entity: dataId}, query: $route.query}">
             <font-awesome-icon icon="search" /> {{ $t('dataexplorer_default_card_info_btn_label') }}
           </router-link>
         </div>

--- a/packages/data-explorer/src/components/dataView/TableRow.vue
+++ b/packages/data-explorer/src/components/dataView/TableRow.vue
@@ -27,7 +27,7 @@
       <router-link
         v-b-tooltip.hover.bottom class="btn btn-sm text-secondary"
         role="button"
-        :to="{ name: 'entity-detail', params: { entityType: tableName, entity: id}}"
+        :to="{ name: 'entity-detail', params: { entityType: tableName, entity: id}, query: $route.query}"
       >
         <font-awesome-icon icon="search" />
       </router-link>

--- a/packages/data-explorer/src/views/EditDetailTemplate.vue
+++ b/packages/data-explorer/src/views/EditDetailTemplate.vue
@@ -4,7 +4,7 @@
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
           <li class="breadcrumb-item" aria-current="page">
-            <router-link id="headItemTooltipId" :to="{ name: 'de-view', params: { entity: entityType} }">
+            <router-link id="headItemTooltipId" :to="{ name: 'de-view', params: { entity: entityType}, query: $route.query }">
               <b-tooltip
                 v-if="tableMeta.description" placement="bottom"
                 target="headItemTooltipId"

--- a/packages/data-explorer/src/views/EntityDetail.vue
+++ b/packages/data-explorer/src/views/EntityDetail.vue
@@ -4,7 +4,7 @@
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
           <li class="breadcrumb-item" aria-current="page">
-            <router-link id="headItemTooltipId" :to="{ name: 'de-view', params: { entity: entityType} }">
+            <router-link id="headItemTooltipId" :to="{ name: 'de-view', params: { entity: entityType}, query: $route.query }">
               <b-tooltip
                 v-if="metaData.description" placement="bottom"
                 target="headItemTooltipId"

--- a/packages/data-explorer/tests/unit/components/dataView/DefaultCardContent.spec.ts
+++ b/packages/data-explorer/tests/unit/components/dataView/DefaultCardContent.spec.ts
@@ -1,7 +1,7 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import DefaultCardContent from '@/components/dataView/DefaultCardContent.vue'
 
-const mocks = { $t: (msg: any) => msg }
+const mocks = { $t: (msg: any) => msg, $route: {query: {foo: 'bar'}} }
 const stubs = ['b-overlay', 'router-link', 'font-awesome-icon']
 
 describe('DefaultCardContent.vue', () => {

--- a/packages/data-explorer/tests/unit/components/dataView/TableRow.spec.ts
+++ b/packages/data-explorer/tests/unit/components/dataView/TableRow.spec.ts
@@ -16,7 +16,7 @@ const getWrapper = (propsData) => {
       showSelected: false
     },
     stubs: ['font-awesome-icon', 'router-link'],
-    mocks: { $t: (msg: any) => msg }
+    mocks: { $t: (msg: any) => msg, $route: {query: {foo: 'bar'}} }
   })
 
   return wrapper

--- a/packages/data-explorer/tests/unit/views/EditDetailTemplate.spec.ts
+++ b/packages/data-explorer/tests/unit/views/EditDetailTemplate.spec.ts
@@ -11,7 +11,8 @@ jest.mock('@/repository/dataRepository', () => {
 
 const mocks = {
   $bvModal: { msgBoxConfirm: jest.fn() },
-  $router: { push: jest.fn() }
+  $router: { push: jest.fn() },
+  $route: {query: {foo: 'bar'}}
 }
 const stubs = ['font-awesome-icon', 'router-link', 'b-tooltip']
 const directives = { 'b-tooltip': () => {} }

--- a/packages/data-explorer/tests/unit/views/EntityDetail.spec.ts
+++ b/packages/data-explorer/tests/unit/views/EntityDetail.spec.ts
@@ -18,7 +18,8 @@ jest.mock('@/repository/dataRepository', () => {
 
 const mocks = {
   $bvModal: { msgBoxConfirm: jest.fn() },
-  router: { replace: jest.fn() }
+  router: { replace: jest.fn() },
+  $route: {query: {foo: 'bar'}}
 }
 const stubs = ['font-awesome-icon', 'router-link', 'b-tooltip']
 const directives = { 'b-tooltip': () => {} }


### PR DESCRIPTION
If a user has a active query and visits a details page, and then returns to the overview.
The query from the overview is used

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
