### PR TITLE
feat(metadata-manager): add entity type id input

### DIFF
--- a/packages/metadata-manager/src/components/MetadataManagerContainer.vue
+++ b/packages/metadata-manager/src/components/MetadataManagerContainer.vue
@@ -16,7 +16,7 @@
     <div v-else>
       <div class="row">
         <div class="col">
-          <div v-if="editorEntityType && editorEntityType.id !== ''">
+          <div v-if="editorEntityType && (editorEntityType.id !== '' || editorEntityType.isNew)">
             <metadata-manager-entity-edit-form></metadata-manager-entity-edit-form>
             <hr>
           </div>
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col">
           <metadata-manager-attribute-edit-form
-            v-if="editorEntityType && editorEntityType.id !== ''"></metadata-manager-attribute-edit-form>
+            v-if="editorEntityType && (editorEntityType.id !== '' || editorEntityType.isNew)"></metadata-manager-attribute-edit-form>
         </div>
       </div>
     </div>

--- a/packages/metadata-manager/src/components/MetadataManagerEntityEditForm.vue
+++ b/packages/metadata-manager/src/components/MetadataManagerEntityEditForm.vue
@@ -38,8 +38,15 @@
         </div>
       </div>
 
-      <!-- Column containing: Label, Description and Package -->
+      <!-- Column containing: Id, Label, Description and Package -->
       <div class="col-md-4 col-sm-12 col-xs-12 inner-column">
+        <div class="form-group row">
+          <label class="col-4 col-form-label text-muted">ID</label>
+          <div class="col input-group">
+            <input v-model="id" class="form-control" type="text" :placeholder="$t('entity-edit-form-id-placeholder')" :disabled="!editorEntityType.isNew">
+          </div>
+        </div>
+
         <div class="form-group row">
           <label class="col-4 col-form-label text-muted">{{ 'entity-edit-form-label-label' | i18n
             }}</label>
@@ -217,6 +224,14 @@
         },
         set (value) {
           this.$store.commit(UPDATE_EDITOR_ENTITY_TYPE, {key: 'abstract0', value: value})
+        }
+      },
+      id: {
+        get () {
+          return this.$store.state.editorEntityType.id
+        },
+        set (value) {
+          this.$store.commit(UPDATE_EDITOR_ENTITY_TYPE, {key: 'id', value: value})
         }
       },
       label: {


### PR DESCRIPTION
Default will be an auto id, which can be changed. Existing entity types will show the id but the input will be disabled.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Conventional commits (squash if needed)
- No warnings during install
- Updated javascript typing
- [x] Update releasenotes
