### PR TITLE
fix(core-ui): string date value for expressions

### DIFF
--- a/packages/core-ui/src/modules/react-components/Form.js
+++ b/packages/core-ui/src/modules/react-components/Form.js
@@ -705,10 +705,10 @@ var Form = React.createClass({
 
             switch (attr.fieldType) {
                 case 'DATE':
-                    form[attr.name] = moment(value, 'YYYY-MM-DD', true);
+                    form[attr.name] = value;
                     break;
                 case 'DATE_TIME':
-                    form[attr.name] = moment(value, moment.ISO_8601, true);
+                    form[attr.name] = moment(value, moment.ISO_8601, true).toISOString();
                     break;
                 case 'CATEGORICAL':
                 case 'XREF':


### PR DESCRIPTION
It was feeding a moment object, use iso string instead

Fixes #674

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
-  User documentation updated
- [x] Conventional commits (squash if needed)
-  No warnings during install
-  Updated javascript typing
-  Add to release notes
