### PR TITLE
fix: selection outside initial range not visible on mounted

### DIFF
--- a/packages/components-library/src/components/filters/MultiFilter.vue
+++ b/packages/components-library/src/components/filters/MultiFilter.vue
@@ -296,17 +296,16 @@ export default {
     },
     checkMissingOptions () {
       let values
-      if(this.selection.length && this.returnTypeAsObject) {
+      if (this.selection.length && this.returnTypeAsObject) {
          values = this.selection.map(s => s.value)
-      }
-      else {
+      } else {
         values = selection
       }
 
       const comparison = this.inputOptions.map(io => io.value)
       const newValues = values.filter(value => !comparison.includes(value))
 
-      if(newValues){
+      if (newValues) {
         const newOptions = this.options({
           nameAttribute: 'label',
           queryType: 'in',
@@ -315,7 +314,6 @@ export default {
         this.inputOptions.concat(newOptions)
         this.sortBySelected(this.inputOptions)
       }
-
     },
     setSelection () {
       this.externalUpdate = true

--- a/packages/components-library/src/components/filters/MultiFilter.vue
+++ b/packages/components-library/src/components/filters/MultiFilter.vue
@@ -214,7 +214,9 @@ export default {
       this.$emit('input', newSelection)
     },
     value () {
-      this.setValue()
+      this.setSelection()
+      // We can get a value which might be outside the 100 initial range.
+      this.checkMissingOptions()
     },
     query (queryValue) {
       if (this.triggerQuery) {
@@ -223,7 +225,7 @@ export default {
 
       if (!queryValue.length) {
         const newInititalOptions = [].concat(this.multifilterOptions)
-        this.inputOptions = this.inputOptionsSort(newInititalOptions)
+        this.inputOptions = this.sortBySelected(newInititalOptions)
         return
       }
 
@@ -234,10 +236,10 @@ export default {
 
         this.options({ nameAttribute: 'label', query: this.query }).then(
           searchResults => {
-            const allOptions = searchResults
+              const allOptions = searchResults
               ? searchResults.concat(this.inputOptions)
               : this.inputOptions
-            this.inputOptions = this.inputOptionsSort(allOptions)
+            this.inputOptions = this.sortByQuery(allOptions)
           }
         )
 
@@ -252,26 +254,70 @@ export default {
     this.initializeFilter()
   },
   methods: {
-    inputOptionsSort (optionsArray) {
+    // When you initialize or remove a search, you want to see what you selected
+    sortBySelected (optionsArray) {
       optionsArray.sort((a, b) => {
         if (
           !this.selection.includes(a.value) &&
           !this.selection.includes(b.value)
         ) {
-          return 0
+          return 1
         } else if (
           this.selection.includes(a.value) &&
           !this.selection.includes(b.value)
         ) {
           return -1
-        } else return 1
+        } else {
+          return 0
+        }
       })
 
       return Array.from(new Set(optionsArray.map(cio => cio.value))).map(
         value => optionsArray.find(cio => cio.value === value)
       )
     },
-    setValue () {
+    // When you search you want to quickly see your search results.
+    sortByQuery (optionsArray) {
+      optionsArray.sort((a, b) => {
+        if (a.value.indexOf(this.query) === -1 && b.value.indexOf(this.query) === -1) {
+          return 1
+        } else if (
+          a.value.indexOf(this.query) >= 0 &&
+          b.value.indexOf(this.query) === -1
+        ) {
+          return -1
+        } else {
+          return 0
+        }
+      })
+      return Array.from(new Set(optionsArray.map(cio => cio.value))).map(
+        value => optionsArray.find(cio => cio.value === value)
+      )
+    },
+    checkMissingOptions () {
+      let values
+      if(this.selection.length && this.returnTypeAsObject) {
+         values = this.selection.map(s => s.value)
+      }
+      else {
+        values = selection
+      }
+
+      const comparison = this.inputOptions.map(io => io.value)
+      const newValues = values.filter(value => !comparison.includes(value))
+
+      if(newValues){
+        const newOptions = this.options({
+          nameAttribute: 'label',
+          queryType: 'in',
+          query: this.newValues.join(',')
+        })
+        this.inputOptions.concat(newOptions)
+        this.sortBySelected(this.inputOptions)
+      }
+
+    },
+    setSelection () {
       this.externalUpdate = true
       this.selection =
         typeof this.value[0] === 'object'
@@ -285,7 +331,7 @@ export default {
       let selectedOptions = []
 
       if (this.value && this.value.length) {
-        this.setValue()
+        this.setSelection()
         // Get the initial selected
         selectedOptions = await this.options({
           nameAttribute: 'label',
@@ -303,7 +349,7 @@ export default {
       )
 
       // deduplicate by first mapping the id's then getting the first matching object back.
-      this.initialOptions = this.inputOptionsSort(completeInitialOptions)
+      this.initialOptions = this.sortBySelected(completeInitialOptions)
       this.inputOptions = this.initialOptions
     }
   }
@@ -334,6 +380,23 @@ Item-based Filter. Search box is used to find items in the table.
 ```jsx
 
 const model = []
+<MultiFilter
+  v-bind:returnTypeAsObject="false"
+  v-bind:options="multiFilterOptions"
+  v-bind:collapses="false"
+  v-bind:initialDisplayItems="5"
+  v-bind:maxVisibleOptions="5"
+  v-bind:optionsWarningCount="10"
+  v-model="model"
+  name="multi-filter">
+</MultiFilter>
+<div>{{model}}</div>
+```
+
+Preselected item, outside of initial options:
+```jsx
+
+const model = ['sugar-apple']
 <MultiFilter
   v-bind:returnTypeAsObject="false"
   v-bind:options="multiFilterOptions"

--- a/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
+++ b/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
@@ -161,7 +161,6 @@ describe('MultiFilter.vue', () => {
       wrapper = mount(MultiFilter, { localVue, propsData })
       const satisfyAllButton = wrapper.find('input[name="satisfy-all"]')  
       expect (satisfyAllButton.exists()).toBe(false)
-      
     })
     
     it('triggers the proper emit when the satisfyAll checkbox is clicked', async () => {
@@ -212,7 +211,6 @@ describe('MultiFilter.vue', () => {
       const firstCheckbox = wrapper.find('input[type="checkbox"]')
       expect(firstCheckbox.attributes().value).toEqual('sugar-apple')
       expect(firstCheckbox.element.checked).toBeTruthy()
-
     })
   })
 })

--- a/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
+++ b/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import MultiFilter from '@/components/filters/MultiFilter.vue'
 import SatisfyAllCheckbox from '@/components/blocks/SatisfyAllCheckbox.vue'
 import { localVue as getLocalVue } from '../../lib/helpers'
@@ -180,6 +180,39 @@ describe('MultiFilter.vue', () => {
       const satisfyAllButton = wrapper.find('input[name="satisfy-all"]')
       await satisfyAllButton.trigger('click')
       expect(wrapper.emitted('satisfy-all')).toEqual([[true]])
+    })
+
+    it('finds an option outside the initialOptions and marks it as selected when passed as value', async () => {
+      const propsData = {
+        name: 'multi-filter',
+        value: ['sugar-apple'],
+        type: 'multi-filter',
+        label: 'Filter with multiple options',
+        collapsed: false,
+        maxVisibleOptions: 10,
+        options: jest.fn((value) => {
+          if(value.query && value.query === 'sugar-apple'){
+           return Promise.resolve([
+              { value: 'sugar-apple', text: 'Sugar Apple' },
+            ])
+          }
+          else {
+           return Promise.resolve([
+              { value: 'red', text: 'Red' },
+              { value: 'green', text: 'Green' }])
+            }
+        })
+      }
+
+      wrapper = mount(MultiFilter, { localVue, propsData })
+      // wait until all is processed:
+      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick()
+      // expected outcome is that Sugar Apple is our first checkbox
+      const firstCheckbox = wrapper.find('input[type="checkbox"]')
+      expect(firstCheckbox.attributes().value).toEqual('sugar-apple')
+      expect(firstCheckbox.element.checked).toBeTruthy()
+
     })
   })
 })

--- a/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
+++ b/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
@@ -1,4 +1,4 @@
-import { mount, shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import MultiFilter from '@/components/filters/MultiFilter.vue'
 import SatisfyAllCheckbox from '@/components/blocks/SatisfyAllCheckbox.vue'
 import { localVue as getLocalVue } from '../../lib/helpers'


### PR DESCRIPTION
fix: when initialized with a value outside it's initial range, it is now retrieved and sorted on top, checked

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
-  User documentation updated
- [x] Conventional commits (squash if needed)
-  No warnings during install
- Updated javascript typing
- [x] Add to release notes
