### PR TITLE
fix/697 form settings data

### DIFF
--- a/packages/data-explorer/src/store/explorer/actions.ts
+++ b/packages/data-explorer/src/store/explorer/actions.ts
@@ -173,14 +173,20 @@ export default {
     }
   },
 
-  fetchFormSettings: async ({ commit }: { commit: any }) => {
+  fetchFormSettings: async ({ commit, state }: { commit: any, state: ApplicationState }) => {
+    if (state.formSettings) return
     try {
       const response = await client.get("/api/data/sys_set_forms/forms")
-      commit('setFormSettings', response.data)
+      commit('setFormSettings', response.data.data)
     } catch (error) {
       commit('addToast', {
         message: 'Failed to fetch form settings. ' + error.message,
         type: 'danger'
+      })
+      commit('setFormSettings', {
+        addBooleanNullOption: true,
+        addCategoricalNullOption: true,
+        addEnumNullOption: true
       })
     }
   },

--- a/packages/data-explorer/src/store/explorer/state.ts
+++ b/packages/data-explorer/src/store/explorer/state.ts
@@ -4,11 +4,7 @@ import { Pagination } from '@molgenis-ui/components-library'
 export const defaultPagination:Pagination = { count: 0, loading: false, page: 1, size: 20 }
 
 const state: ApplicationState = {
-  formSettings: {
-    addBooleanNullOption: true,
-    addCategoricalNullOption: true,
-    addEnumNullOption: true
-  },
+  formSettings: null,
   toasts: [],
   settingsTable: 'sys_ts_DataExplorerEntitySettings',
   tableName: null,

--- a/packages/data-explorer/src/types/ApplicationState.ts
+++ b/packages/data-explorer/src/types/ApplicationState.ts
@@ -64,7 +64,7 @@ export interface FormSettings {
 }
 
 export default interface ApplicationState {
-  formSettings: FormSettings
+  formSettings: FormSettings | null
   toasts: Toast[]
   settingsTable: string
   dataDisplayLayout: 'CardView' | 'TableView'

--- a/packages/data-explorer/tests/unit/store/explorer/actions.spec.ts
+++ b/packages/data-explorer/tests/unit/store/explorer/actions.spec.ts
@@ -7,6 +7,7 @@ import * as metaDataService from '@/repository/metaDataService'
 import * as metaFilterMapper from '@/mappers/metaFilterMapper'
 import Vue from 'vue'
 import client from '@/lib/client'
+import { AxiosResponse } from 'axios'
 
 const metaResponse = {
   meta: {
@@ -204,44 +205,38 @@ const dataResponse = {
 }
 
 const mockResponses: {[key:string]: Object} = {
-  '/api/data/entity': { 'loaded': true },
+  '/api/data/entity': {},
   '/api/v2/sys_job_ResourceDownloadJobExecution/failure': {
-    data: {
-      progressMessage: 'failed',
-      status: 'FAILED'
-    }
+    progressMessage: 'failed',
+    status: 'FAILED'
   },
   '/api/v2/sys_job_ResourceDownloadJobExecution/success': {
-    data: {
-      progressMessage: 'progress',
-      resultUrl: '/foo/bar',
-      status: 'SUCCESS'
-    }
+    progressMessage: 'progress',
+    resultUrl: '/foo/bar',
+    status: 'SUCCESS'
   },
   '/api/data/entity?expand=xcategorical_value&filter=id,xbool,xcategorical_value(label)': dataResponse,
   '/api/v2/entity?num=0': metaResponse,
-  '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithOutSettings"': { data: { items: [] } },
-  '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithSettings"': { data: { items: [{ data: { id: 'ent-set', shop: true, collapse_limit: 5 } }] } },
+  '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithOutSettings"': { items: [] },
+  '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithSettings"': { items: [{ data: { id: 'ent-set', shop: true, collapse_limit: 5 } }] },
   '/api/data/sys_ts_DataExplorerEntitySettings': {},
-  '/api/data/sys_set_forms/forms': {"data": {"data":{"addEnumNullOption":false,"addBooleanNullOption":false,"addCategoricalNullOption":false,"id":"forms"}}},
+  '/api/data/sys_set_forms/forms': { "data":{ "addEnumNullOption":false,"addBooleanNullOption":false,"addCategoricalNullOption":false,"id":"forms" } },
   '/api/v2/my-table?start=0&num=0': {
-    data: {
-      meta: {
-        permissions: ['PERM_A']
-      }
+    meta: {
+      permissions: ['PERM_A']
     }
   }
 }
 
 jest.mock('@/lib/client', () => {
   return {
-    get: (url: string) => {
+    get: (url: string): Promise<AxiosResponse> => {
       const mockResp = mockResponses[url]
       if (!mockResp) {
         // eslint-disable-next-line no-console
         console.warn(`mock url (${url}) called but not found in ${JSON.stringify(mockResponses, null, 4)}`)
       }
-      return Promise.resolve(mockResp)
+      return Promise.resolve({ data: mockResp, status: 200, statusText: 'OK', headers: {}, config: {} })
     },
     post: jest.fn(),
     patch: jest.fn()
@@ -553,7 +548,7 @@ describe('actions', () => {
     it('should fetch the form settings and commit them to the store', async () => {
       await actions.fetchFormSettings({ commit, state })
       expect(commit).toHaveBeenCalledWith('setFormSettings',
-        {"addEnumNullOption":false,"addBooleanNullOption":false,"addCategoricalNullOption":false,"id":"forms"})
+        { "addEnumNullOption":false,"addBooleanNullOption":false,"addCategoricalNullOption":false,"id":"forms" })
     })
   })
 

--- a/packages/data-explorer/tests/unit/store/explorer/actions.spec.ts
+++ b/packages/data-explorer/tests/unit/store/explorer/actions.spec.ts
@@ -223,6 +223,7 @@ const mockResponses: {[key:string]: Object} = {
   '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithOutSettings"': { data: { items: [] } },
   '/api/data/sys_ts_DataExplorerEntitySettings?q=table=="tableWithSettings"': { data: { items: [{ data: { id: 'ent-set', shop: true, collapse_limit: 5 } }] } },
   '/api/data/sys_ts_DataExplorerEntitySettings': {},
+  '/api/data/sys_set_forms/forms': {"data": {"data":{"addEnumNullOption":false,"addBooleanNullOption":false,"addCategoricalNullOption":false,"id":"forms"}}},
   '/api/v2/my-table?start=0&num=0': {
     data: {
       meta: {
@@ -545,6 +546,14 @@ describe('actions', () => {
       await actions.fetchTableSettings({ commit, state }, { tableName: 'tableWithOutSettings' })
       expect(commit).toHaveBeenCalledWith('setTableSettings', {})
       expect(commit).not.toHaveBeenCalledWith('setTableSettings', { id: 'ent-set', shop: true, collapse_limit: 5 })
+    })
+  })
+
+  describe('fetchFormSetttings', () => {
+    it('should fetch the form settings and commit them to the store', async () => {
+      await actions.fetchFormSettings({ commit, state })
+      expect(commit).toHaveBeenCalledWith('setFormSettings',
+        {"addEnumNullOption":false,"addBooleanNullOption":false,"addCategoricalNullOption":false,"id":"forms"})
     })
   })
 


### PR DESCRIPTION
* I didn't know that axios client is used in data explorer 2 and that the response is actually in response.data.
* Looks like I'm not the only one, the tests did not always put the mock response in the data field. I've fixed that in the actions spec, making the error harder to repeat
* The form settings need to be awaited before the form is created, fetch them in parallel with the form data

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Conventional commits (squash if needed)
- No warnings during install
- Updated javascript typing
- [x] Add to release notes
