### PR TITLE
fix: multifilter now correctly emit selected values when searching and has return objects enabled

### DIFF
--- a/packages/components-library/src/components/filters/MultiFilter.vue
+++ b/packages/components-library/src/components/filters/MultiFilter.vue
@@ -195,7 +195,8 @@ export default {
     }
   },
   watch: {
-    selection (newValue) {
+    async selection (newValue) {
+
       let newSelection
       if (this.externalUpdate) {
         this.externalUpdate = false
@@ -203,6 +204,8 @@ export default {
       }
 
       if (this.returnTypeAsObject) {
+        await this.checkMissingOptions()
+      
         newSelection = Object.assign(
           newValue,
           this.multifilterOptions.filter(mfo => newValue.includes(mfo.value))
@@ -210,20 +213,19 @@ export default {
       } else {
         newSelection = [...newValue]
       }
-
+      
       this.$emit("input", newSelection)
     },
-    async value () {
+    value () {
       this.setSelection()
-      // We can get a value which might be outside the 100 initial range.
-      await this.checkMissingOptions()
     },
-    query (queryValue) {
+    async query (queryValue) {
       if (this.triggerQuery) {
         clearTimeout(this.triggerQuery)
       }
 
       if (!queryValue || !queryValue.length) {
+
         this.inputOptions = this.sort(this.initialOptions)
         return
       }
@@ -312,10 +314,9 @@ export default {
 
       const comparison = this.inputOptions.map(io => io.value)
       const newValues = values.filter(value => !comparison.includes(value))
-
       if (newValues.length) {
         const newOptions = await this.options({
-          nameAttribute: "label",
+          nameAttribute: "id",
           queryType: "in",
           query: newValues.join(",")
         })
@@ -339,7 +340,7 @@ export default {
         this.setSelection()
         // Get the initial selected
         selectedOptions = await this.options({
-          nameAttribute: "label",
+          nameAttribute: "id",
           queryType: "in",
           query: this.selection.join(",")
         })

--- a/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
+++ b/packages/components-library/tests/unit/filters/MultiFilter.spec.ts
@@ -164,7 +164,11 @@ describe('MultiFilter.vue', () => {
       wrapper.setProps({ returnTypeAsObject: true })
       const checkbox = wrapper.find('input[type=checkbox]').element as HTMLInputElement
       await checkbox.click()
-      expect(wrapper.emitted().input).toEqual([[[{ text: 'Red', value: 'red' }]]])
+
+      // waiting for async behaviour
+      wrapper.vm.$nextTick(() => 
+        expect(wrapper.emitted().input).toEqual([[[{ text: 'Red', value: 'red' }]]])
+      )
     })
   })
 


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
-  No warnings during install
-  Updated javascript typing
- [x] Add to release notes
